### PR TITLE
Fix/nex 91/import js changes before merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -521,7 +521,7 @@ var inputLimiter = function userInputLimier(interaction) {
 
                 // insert the cut-off text
                 if (isCke) {
-                    _getCKEditor(interaction).insertText(newValue);
+                    _getCKEditor(interaction).insertHtml(newValue);
                 } else {
                     containerHelper
                         .get(interaction)


### PR DESCRIPTION
There was a small JS change in the repo we are about to migrate all the JS out of: https://github.com/oat-sa/extension-tao-itemqti/pull/1303/files

I have to import the small change into the npm package and re-release it, so that everything is preserved when we delete all the old JS sources (https://github.com/oat-sa/extension-tao-itemqti/pull/1299) and install the package.

`npm i && npm run test` to check it works.