### PR TITLE
TAO-8725 draggable event executed before dropzone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1232,11 +1232,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-            "dev": true
-        },
-        "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
             "dev": true
         },
         "external-editor": {
@@ -2782,8 +2777,11 @@
             "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.1.4.tgz",
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
-            "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+            "dependencies": {
+                "eve": {
+                    "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+                    "from": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+                }
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -492,8 +492,9 @@ var render = function(interaction) {
                             onend: function(e) {
                                 var $target = $(e.target);
                                 $target.removeClass('dragged');
-                                _resetSelection();
-
+                                _.delay(function(){
+                                    _resetSelection();
+                                });
                                 interactUtils.restoreOriginalPosition($target);
                                 interactUtils.iFrameDragFixOff();
                             }

--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -492,6 +492,7 @@ var render = function(interaction) {
                             onend: function(e) {
                                 var $target = $(e.target);
                                 $target.removeClass('dragged');
+                                // The reason of placing delay here is that there was timing conflict between "draggable" and "drag-zone" elements.
                                 _.delay(function(){
                                     _resetSelection();
                                 });


### PR DESCRIPTION
**task:** https://oat-sa.atlassian.net/browse/TAO-8725
**description:** 
on hybrid laptops ( both with keyboard and touchscreen) all plugins (widgets) of test runner were unable to move through the touchscreen instead of mouse or touchpad. 

At this particular package there was a problem with fired events order for dragged and dropable components.

**solution**
Was decided to postpone draggable element *drag end* and fire it after dropable element.

**related PR**
https://github.com/oat-sa/tao-core/pull/2251