### PR TITLE
fix/TAO-9085/minChoices and maxChoices can be equal to the size of choices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2794,7 +2794,7 @@
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/GraphicOrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/GraphicOrderInteraction.js
@@ -119,9 +119,9 @@ var _renderOrderList = function _renderOrderList(interaction, $orderList) {
     var max = interaction.attr('maxChoices');
 
     //calculate the number of orderer to display
-    if (max > 0 && max < size) {
+    if (max > 0 && max <= size) {
         size = max;
-    } else if (min > 0 && min < size) {
+    } else if (min > 0 && min <= size) {
         size = min;
     }
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9085

Related PR: https://github.com/oat-sa/extension-tao-itemqti/pull/1336

The issue:  if `maxChoices = size of choices` then condition `if (max > 0 && max < size) {` didn't match and  `} else if (min > 0 && min < size) {
        size = min;
 }` So the size set in minChoices
https://github.com/oat-sa/tao-item-runner-qti-fe/blob/f7d7bb46f3d9e579dd8011215a942454709d07a7/src/qtiCommonRenderer/renderers/interactions/GraphicOrderInteraction.js#L115-L126
https://github.com/oat-sa/extension-tao-itemqti/blob/02b6cd67f00ffe5e2ca9d1ee2403a2e351e94023/views/js/qtiCreator/widgets/interactions/graphicOrderInteraction/Widget.js#L78-L90

Fix:
In calculation, minChoices and maxChoices can be equal to the size of choices.
**Changes in 2 files in `tao-item-runner-qti-fe` and `extension-tao-itemqti`**

How to test:

1. Create an item
2. Drag and Drop a Graphic Order Interaction to the canvas
3. Select the BG
4. Create 2 figures
5. Check the Min and Max choices in "Allowed choices", on the right side, so that Max=1, Min=1
6. In Response mode, choose first figure - figure gets digit 1, second figure - max choices warning
7. In Question mode, modify Max to 2 
8. In Response mode, try to choose one more figure