### PR TITLE
fix/TAO-9084/GraphicOrderInteraction prevent duplicated associations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/GraphicAssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/GraphicAssociateInteraction.js
@@ -310,15 +310,15 @@ var _shapesSelectable = function _shapesSelectable(interaction, active) {
     //update the shape state
     _.forEach(choices, function(choice) {
         var element;
-        var assocsElemet;
+        var assocsElement;
         if (!_.contains(assocs, choice.id())) {
             element = interaction.paper.getById(choice.serial);
-            assocsElemet = element.data('assocs') || [];
+            assocsElement = element.data('assocs') || [];
             if (
                 !element.active &&
                 element.id !== active.id &&
                 _isMatchable(element, active) &&
-                !_.contains(assocsElemet, activeChoice.id())) {
+                !_.contains(assocsElement, activeChoice.id())) {
                 element.selectable = true;
                 graphic.updateElementState(element, 'selectable');
             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9084

1. Issue: the user could create association 1->2 and then 2->1
Fix: was added the check to function `_shapesSelectable ` if in attribute `data-assocs` of an element presented `id` of active then this element is not selectable.

2. Also was fixed removing the association(when removing one association causes removing all associations of this element): 
                        active.data('assocs', _.remove(active.data('assocs') || [], choice.id()));
was changed to
                        active.data('assocs', _.pull(active.data('assocs') || [], choice.id()));
function `_.remove` always return `[]`

3. Fixed small lint errors.

Steps to Reproduce:
- Create an item
- Drag and drop a Graphic Association Interaction to the canvas
- Select an image as BG
- Add 2 figures to the canvas
- In the Response mode, connect the figures (so the correct response is the !1 connection possible)
- Done, Save, Preview
- In Preview mode, connect the figures
- Notice, that after hitting Submit, you get 1/1
- Connect the figures more times in both directions (1->2, 2->1)
- Notice the score in Submit console
