### PR TITLE
Fix/nec 31/escape attrib equals selector=

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1232,6 +1232,11 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "eve": {
+            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
             "dev": true
         },
         "external-editor": {
@@ -2790,13 +2795,6 @@
             "dev": true,
             "requires": {
                 "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
-            },
-            "dependencies": {
-                "eve": {
-                    "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-                    "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
-                    "dev": true
-                }
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -436,7 +436,7 @@ var setState = function setState(interaction, state) {
         //restore eliminated choices
         if (isEliminable(interaction) && _.isArray(state.eliminated) && state.eliminated.length) {
             _.forEach(state.eliminated, function(identifier) {
-                $container.find('.qti-simpleChoice[data-identifier=' + identifier + ']').addClass('eliminated');
+                $container.find('.qti-simpleChoice[data-identifier="' + identifier + '"]').addClass('eliminated');
             });
         }
     }

--- a/src/qtiCommonRenderer/renderers/interactions/GapMatchInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/GapMatchInteraction.js
@@ -85,12 +85,12 @@ var unsetChoice = function(interaction, $choice) {
 
 var getChoice = function(interaction, identifier) {
     var $container = containerHelper.get(interaction);
-    return $('.choice-area [data-identifier=' + identifier + ']', $container);
+    return $('.choice-area [data-identifier="' + identifier + '"]', $container);
 };
 
 var getGap = function(interaction, identifier) {
     var $container = containerHelper.get(interaction);
-    return $('.qti-flow-container [data-identifier=' + identifier + ']', $container);
+    return $('.qti-flow-container [data-identifier="' + identifier + '"]', $container);
 };
 
 /**

--- a/src/qtiCommonRenderer/renderers/interactions/GraphicGapMatchInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/GraphicGapMatchInteraction.js
@@ -578,7 +578,7 @@ var setResponse = function(interaction, response) {
                             responseChoice = isDirectedPairFlipped ? pair[0] : pair[1];
                             responseGap = isDirectedPairFlipped ? pair[1] : pair[0];
                             if (responseChoice === choice.id()) {
-                                $('[data-identifier=' + responseGap + ']', $container).addClass('active');
+                                $('[data-identifier="' + responseGap + '"]', $container).addClass('active');
                                 _selectShape(interaction, element, false);
                             }
                         }

--- a/src/qtiCommonRenderer/renderers/interactions/MatchInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MatchInteraction.js
@@ -77,8 +77,8 @@ var setResponse = function(interaction, response) {
 
     if (typeof response.list !== 'undefined' && typeof response.list.directedPair !== 'undefined') {
         _(response.list.directedPair).forEach(function(directedPair) {
-            var x = $('th[data-identifier=' + directedPair[0] + ']', $container).index() - 1;
-            var y = $('th[data-identifier=' + directedPair[1] + ']', $container)
+            var x = $('th[data-identifier="' + directedPair[0] + '"]', $container).index() - 1;
+            var y = $('th[data-identifier="' + directedPair[1] + '"]', $container)
                 .parent()
                 .index();
 

--- a/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
@@ -568,7 +568,7 @@ var setResponse = function(interaction, response) {
     } else {
         try {
             _.each(pciResponse.unserialize(response, interaction), function(identifier) {
-                $resultArea.append($choiceArea.find('[data-identifier=' + identifier + ']'));
+                $resultArea.append($choiceArea.find('[data-identifier="' + identifier + '"]'));
             });
         } catch (e) {
             throw new Error('wrong response format in argument : ' + e);


### PR DESCRIPTION
**Related to task:** 
https://oat-sa.atlassian.net/browse/NEC-31

**Description:**
When test-taker returns to an item with Gap Match interaction (from graphic interactions) which has a choice identifier that includes full stop "." (e.g. "LT_2019_6kl_6.3_b") system throws error: 
Error: Syntax error, unrecognized expression: [data-identifier=LT_2019_6kl_6.3_b] 

**How to test:**
Import test from the ticket and test with: 
- choice interaction;
- gap match interaction;
- graphic gap match interaction
- match interaction
- order interaction