### PR TITLE
fixed new string value on clipboard paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.12",
+    "version": "0.4.13",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -496,8 +496,8 @@ var inputLimiter = function userInputLimier(interaction) {
                     newValue = e.originalEvent.clipboardData
                         ? e.originalEvent.clipboardData.getData('text')
                         : e.originalEvent.dataTransfer.getData('text') ||
-                          e.originalEvent.dataTransfer.getData('text/plain') ||
-                          '';
+                        e.originalEvent.dataTransfer.getData('text/plain') ||
+                        '';
                 }
 
                 // prevent insertion of non-limited data
@@ -523,10 +523,21 @@ var inputLimiter = function userInputLimier(interaction) {
                 if (isCke) {
                     _getCKEditor(interaction).insertHtml(newValue);
                 } else {
-                    containerHelper
-                        .get(interaction)
-                        .find('textarea')
-                        .val(oldValue + newValue);
+                    let elements = containerHelper.get(interaction).find('textarea');
+                    let el = elements[0];
+                    let {
+                        selectionStart: start,
+                        selectionEnd: end,
+                        value: text
+                    } = el;
+                    elements.val(
+                        text.substring(0, start) +
+                        newValue +
+                        text.substring(end, text.length)
+                    );
+                    el.focus();
+                    el.selectionStart = start + newValue.length;
+                    el.selectionEnd = el.selectionStart;
                 }
 
                 _.defer(function() {


### PR DESCRIPTION
#### Related to:
https://oat-sa.atlassian.net/browse/TAO-9922 WTP-1493
[ACT] - On writing item, text is always pasted to the end.

#### Steps to reproduce
prepare TAO instance, go to taoQtiItem/views/package.json and replace current depencies
`  "dependencies": {
    ...
    "@oat-sa/tao-item-runner-qti": "0.4.9"
  }`
with this branch:
`  "dependencies": {
    ...
    "@oat-sa/tao-item-runner-qti": "github:oat-sa/tao-item-runner-qti-fe#fix/TAO-9922/fix-paste-clipboard-to-textarea"
  }`
then run `npm install` in directory `YOUR_PROJECT_ROOT/taoQtiItem/views/`

Login to prepared delivery and run the test with an any text area in the test item. Set focus on the textarea and type the words "one two three", then cut last word to the clipboard. Now set the text cursor between "one" and "two" and press keyboard shortcut to insert word "three". Result must be "one three two".

#### Dependencies
Requires : nothing
