### PR TITLE
fix template of text interaction to remove unwanted word "recommended"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/interactions/extendedTextInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/extendedTextInteraction.tpl
@@ -14,7 +14,7 @@
         {!-- If there's an expected length or a max length --}}
         {{#if attributes.expectedLength}}
             <div class="text-counter">
-                <span class="count-chars">0</span> {{__ "of"}} {{attributes.expectedLength}} {{__ "chars"}} {{__ "recommanded"}}.
+                <span class="count-chars">0</span> {{__ "of"}} {{attributes.expectedLength}} {{__ "chars"}}.
             </div>
         {{/if}}
         {{#if maxLength}}
@@ -37,7 +37,7 @@
         {{!-- If there's an expected length or a max length --}}
         {{#if attributes.expectedLength}}
             <div class="text-counter">
-                <span class="count-chars">0</span> {{__ "of"}} {{attributes.expectedLength}} {{__ "chars"}} {{__ "recommended"}}.
+                <span class="count-chars">0</span> {{__ "of"}} {{attributes.expectedLength}} {{__ "chars"}}.
             </div>
         {{/if}}
         {{#if maxLength}}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/ACTP-220

Text interaction - remove word "recommended"

#### Steps to reproduce
- Prepare a test with text interaction (plain text) and create a delivery with this text.
- Log in as a test taker and run this delivery.
- See a string "... chars recommended" at bottom of an opened textarea.

#### How to test
- Replace tao-item-runner-qti module with fixed version
- Re-run the test
- Compare mentioned string with previous version. Word "recommended" disappears.