### PR TITLE
fix error with event customcssloaded.styleeditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/helpers/itemStylesheetHandler.js
+++ b/src/qtiCommonRenderer/helpers/itemStylesheetHandler.js
@@ -25,7 +25,7 @@ import _ from 'lodash';
 //throttle events because of the loop
 var informLoaded = _.throttle(
     function() {
-        $(document).trigger('customcssloaded.styleeditor');
+        $(document).trigger('customcssloaded.styleeditor',[{}]);
     },
     10,
     { leading: false }


### PR DESCRIPTION
Error with the event 'customcssloaded.styleeditor'
After Preview was moved from iframe to document https://oat-sa.atlassian.net/browse/TAO-8134
event from iframe now in the same document as editor.

How to test:

1. go to the Items page
2. go to Authoring
3. go to Preview