### PR TITLE
Feature/actp 315/a11y choice interaction and text entry reponse item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2794,7 +2794,7 @@
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
@@ -1,6 +1,6 @@
 <li class="qti-choice qti-simpleChoice" data-identifier="{{attributes.identifier}}" data-serial="{{serial}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
     <div class="pseudo-label-box">
-        <label class="real-label">
+        <label class="real-label" aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}">
             {{#if unique}}
             <input type="radio" name="response-{{interaction.serial}}" value="{{attributes.identifier}}" tabindex="1">
             <span class="icon-radio"></span>
@@ -10,7 +10,7 @@
             {{/if}}
         </label>
         <div class="label-box">
-            <div class="label-content clear" contenteditable="false">
+            <div class="label-content clear" contenteditable="false" id="choice-{{interaction.serial}}-{{attributes.identifier}}">
                 {{{body}}}
                 <svg class="overlay-answer-eliminator">
                     <line x1="0" y1="100%" x2="100%" y2="0"/>

--- a/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
@@ -1,11 +1,23 @@
 <li class="qti-choice qti-simpleChoice" data-identifier="{{attributes.identifier}}" data-serial="{{serial}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
     <div class="pseudo-label-box">
-        <label class="real-label" aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}">
+        <label class="real-label">
             {{#if unique}}
-            <input type="radio" name="response-{{interaction.serial}}" value="{{attributes.identifier}}" tabindex="1">
+            <input
+                type="radio"
+                name="response-{{interaction.serial}}"
+                value="{{attributes.identifier}}"
+                tabindex="1"
+                aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}"
+            >
             <span class="icon-radio"></span>
             {{else}}
-            <input type="checkbox" name="response-{{interaction.serial}}" value="{{attributes.identifier}}" tabindex="1">
+            <input
+                type="checkbox"
+                name="response-{{interaction.serial}}"
+                value="{{attributes.identifier}}"
+                tabindex="1"
+                aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}"
+            >
             <span class="icon-checkbox"></span>
             {{/if}}
         </label>

--- a/src/qtiCommonRenderer/tpl/interactions/choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/choiceInteraction.tpl
@@ -5,9 +5,12 @@
   data-qti-class="choiceInteraction"
   {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
 >
-  {{#if prompt}}{{{prompt}}}{{/if}}
+  {{#if prompt}}{{{ prompt }}}{{/if}}
   <div class="instruction-container"></div>
-  <ol class="plain block-listing solid choice-area{{#if horizontal}} horizontal{{/if}} {{#if listStyle}}{{{listStyle}}}{{/if}}">
+  <ol
+    class="plain block-listing solid choice-area{{#if horizontal}} horizontal{{/if}} {{#if listStyle}}{{{listStyle}}}{{/if}}"
+    aria-labelledby="{{promptId}}"
+  >
       {{#choices}}{{{.}}}{{/choices}}
   </ol>
   <div class="notification-container"></div>

--- a/src/qtiCommonRenderer/tpl/interactions/extendedTextInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/extendedTextInteraction.tpl
@@ -8,7 +8,12 @@
             {{/each}}
         {{else}}
             {{#each maxStringLoop}}
-                <textarea class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" name="{{attributes.identifier}}_{{this}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"{{/if}}></textarea>
+                <textarea
+                    class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
+                    name="{{attributes.identifier}}_{{this}}"
+                    {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"{{/if}}
+                    aria-labelledby="{{promptId}}"
+                ></textarea>
             {{/each}}
         {{/equal}}
         {!-- If there's an expected length or a max length --}}
@@ -32,7 +37,11 @@
         {{#equal attributes.format xhtml}}
             <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" contenteditable></div>
         {{else}}
-            <textarea class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"{{/if}}></textarea>
+            <textarea
+                class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
+                {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"{{/if}}
+                aria-labelledby="{{promptId}}"
+            ></textarea>
         {{/equal}}
         {{!-- If there's an expected length or a max length --}}
         {{#if attributes.expectedLength}}

--- a/src/qtiCommonRenderer/tpl/interactions/prompt.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/prompt.tpl
@@ -1,7 +1,6 @@
 <div
     class="qti-prompt-container"
     data-html-editable-container{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
-    id="prompt-{{serial}}"
 >
     <div class="qti-prompt" data-serial="{{serial}}" data-html-editable id="prompt-{{serial}}">{{{body}}}</div>
 </div>

--- a/src/qtiCommonRenderer/tpl/interactions/prompt.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/prompt.tpl
@@ -1,3 +1,7 @@
-<div class="qti-prompt-container" data-html-editable-container{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
-    <div class="qti-prompt" data-serial="{{serial}}" data-html-editable>{{{body}}}</div>
+<div
+    class="qti-prompt-container"
+    data-html-editable-container{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
+    id="prompt-{{serial}}"
+>
+    <div class="qti-prompt" data-serial="{{serial}}" data-html-editable id="prompt-{{serial}}">{{{body}}}</div>
 </div>

--- a/src/qtiItem/core/interactions/BlockInteraction.js
+++ b/src/qtiItem/core/interactions/BlockInteraction.js
@@ -24,6 +24,7 @@ var BlockInteraction = Interaction.extend({
         var args = rendererConfig.getOptionsFromArguments(arguments),
             renderer = args.renderer || this.getRenderer(),
             defaultData = {
+                promptId: `prompt-${this.prompt.getSerial()}`,
                 prompt: this.prompt.render(renderer)
             };
 


### PR DESCRIPTION
**Jira ticket:**
https://oat-sa.atlassian.net/browse/ACTP-315

**Description:**
Added reading text question to extended text and simple choice interactions response and added reading choices to the simple choice interaction

**How to test:**

1. Change locally `package.json` file in `tao-qti-item/views`, `@oat-sa/tao-item-runner-qti` dependency version should be: `git@github.com:oat-sa/tao-item-runner-qti-fe.git#feature/ACTP-315/a11y-Choice-Interaction-and-Text-Entry-reponse-item`
2. Run `npm i`
3. Create test with simple choice items and extended text
4. Enable screen reader
5. Run the test as test taker. Question and choices should be readable, when the response item receives the focus



