### PR TITLE
Feature/NEC-71/mime types for cpp and pascal files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.17",
+    "version": "0.4.18",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -178,11 +178,12 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-0.8.1.tgz",
-            "integrity": "sha512-pYvHgl3IYyUKCMJb4McOJ767hKeDQDo1MOYKp0Hb9dTXVNc95/+u9VrgmTXUmPSdkOixNz54efAPDuy/wONTBw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.2.0.tgz",
+            "integrity": "sha512-1M9w4RhTx8vgkNfOdMz8KpYZDkNg5pab1/0v+NEH9evAHttdwgqS+NzyjF8GGBi3duVW583fyOEh1YUnQLhkVQ==",
             "dev": true,
             "requires": {
+                "fastestsmallesttextencoderdecoder": "^1.0.14",
                 "idb-wrapper": "1.7.0",
                 "webcrypto-shim": "0.1.4"
             }
@@ -1278,6 +1279,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fastestsmallesttextencoderdecoder": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
+            "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ==",
             "dev": true
         },
         "fd-slicer": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.2.0",
-        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#feature/nec-71/add-cpp-and-passcal-files",
+        "@oat-sa/tao-core-sdk": "^1.2.0",
         "@oat-sa/tao-core-ui": "^0.21.4",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.17",
+    "version": "0.4.18",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [
@@ -47,7 +47,7 @@
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.2.0",
-        "@oat-sa/tao-core-sdk": "^0.8.1",
+        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#feature/nec-71/add-cpp-and-passcal-files",
         "@oat-sa/tao-core-ui": "^0.21.4",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/src/qtiCommonRenderer/helpers/uploadMime.js
+++ b/src/qtiCommonRenderer/helpers/uploadMime.js
@@ -56,7 +56,11 @@ var uploadMime = {
                 mime: 'application/vnd.ms-powerpoint',
                 label: __('Microsoft Powerpoint'),
                 equivalent: ['application/vnd.openxmlformats-officedocument.presentationml.presentation']
-            }
+            },
+            { mime: 'application/vnd.oasis.opendocument.text', label: __('OpenDocument text document') },
+            { mime: 'application/vnd.oasis.opendocument.spreadsheet', label: __('OpenDocument spreadsheet document') },
+            { mime: 'text/x-c', label: __('C++ file (.cpp)') },
+            { mime: 'text/pascal', label: __('Pascal file (.pas)') }
         ];
     },
 


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NEC-71
**Description:** Mime types for uploading C++, Pascal and OpenDocument files
**Requires:** 
- [x] release [`tao-core-sdk-fe` ](https://github.com/oat-sa/tao-core-sdk-fe/pull/54)
- [x] update _**package.*.json**_ files

**Unit tests cli:** `npm run test`