### PR TITLE
BOSA 36 - Hidden tooltip when pattern mask matches with 0 value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.18",
+    "version": "0.4.19",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.18",
+    "version": "0.4.19",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -132,7 +132,7 @@ var render = function render(interaction) {
 
             hideTooltip($input);
 
-            if (($input.val().length && regex.test($input.val())) || ($input.val().length && regex.test($input.val()))) {
+            if ($input.val().length && regex.test($input.val()) || $input.val().length === 0 && regex.test($input.val())) {
                 $input.removeClass('invalid');
             } else {
                 $input.addClass('invalid');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -134,7 +134,7 @@ var render = function render(interaction) {
 
             if ($input.val().length && regex.test($input.val())) {
                 $input.removeClass('invalid');
-            } else {
+            } else if ($input.val().length) {
                 $input.addClass('invalid');
                 showTooltip($input, 'error', __('This is not a valid answer'));
             }

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -132,9 +132,9 @@ var render = function render(interaction) {
 
             hideTooltip($input);
 
-            if ($input.val().length && regex.test($input.val())) {
+            if (($input.val().length && regex.test($input.val())) || ($input.val().length && regex.test($input.val()))) {
                 $input.removeClass('invalid');
-            } else if ($input.val().length) {
+            } else {
                 $input.addClass('invalid');
                 showTooltip($input, 'error', __('This is not a valid answer'));
             }

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -132,7 +132,7 @@ var render = function render(interaction) {
 
             hideTooltip($input);
 
-            if ($input.val().length && regex.test($input.val()) || $input.val().length === 0 && regex.test($input.val())) {
+            if (regex.test($input.val())) {
                 $input.removeClass('invalid');
             } else {
                 $input.addClass('invalid');


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/BOSA-36

**Description**

Inline text entry, when you click on the hole in the text, it appears directly "This is not a valid answer": even though you haven't written anything yet. This appears when you select a pattern mask that matches 0 value.

![imagen](https://user-images.githubusercontent.com/34692207/78665139-a207aa80-78d5-11ea-886a-607de31e13bf.png)
