### PR TITLE
BOSA 81 - Fix size in container for avoid responsive mode affect to answer images

### DIFF
--- a/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
@@ -22,7 +22,7 @@
             {{/if}}
         </label>
         <div class="label-box">
-            <div class="label-content clear" contenteditable="false" id="choice-{{interaction.serial}}-{{attributes.identifier}}">
+            <div style="width: 100%;" class="label-content clear" contenteditable="false" id="choice-{{interaction.serial}}-{{attributes.identifier}}">
                 {{{body}}}
                 <svg class="overlay-answer-eliminator">
                     <line x1="0" y1="100%" x2="100%" y2="0"/>


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/BOSA-81

**Description**

The inserted image (in the response alternatives) does not display correctly in the preview.

Precondition: logged in as an admin

Steps to reproduce:

1. Navigate to items
2. Select the specific item with label name "Test 2 - vb vraag ABS A "
![imagen](https://user-images.githubusercontent.com/34692207/78763436-6debc280-7985-11ea-89bc-f7bf3750b37f.png)

3. Click on the authoring button
4 Click on the [Save] button
5. Click on the [Preview]

**Actual result**

The inserted image does not display correctly in the response alternatives. See the attached video.

**Expected result**

The inserted image displays correctly in the response alternatives.