### PR TITLE
BSA 36 - Avoid error message appears in any case before user write something

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 dist
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.19",
+    "version": "0.4.20",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.19",
+    "version": "0.4.20",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -111,7 +111,9 @@ var render = function render(interaction) {
                 messageType = 'info';
             }
 
-            if (count) showTooltip($input, messageType, message);
+            if (count) {
+                showTooltip($input, messageType, message);
+            }
         };
 
         $input

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -111,8 +111,9 @@ var render = function render(interaction) {
                 messageType = 'info';
             }
 
-            if (count) {
-                showTooltip($input, messageType, message);
+            showTooltip($input, messageType, message);
+            if (count && messageType === 'warning') {
+                hideTooltip($input);
             }
         };
 

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -111,7 +111,7 @@ var render = function render(interaction) {
                 messageType = 'info';
             }
 
-            showTooltip($input, messageType, message);
+            if (count) showTooltip($input, messageType, message);
         };
 
         $input
@@ -130,15 +130,15 @@ var render = function render(interaction) {
         updatePatternMaskTooltip = function updatePatternMaskTooltip() {
             var regex = new RegExp(attributes.patternMask);
 
-            if (!$input.val().length) return;
-
             hideTooltip($input);
 
-            if (regex.test($input.val())) {
-                $input.removeClass('invalid');
-            } else {
-                $input.addClass('invalid');
-                showTooltip($input, 'error', __('This is not a valid answer'));
+            if ($input.val()) {
+                if (regex.test($input.val())) {
+                    $input.removeClass('invalid');
+                } else {
+                    $input.addClass('invalid');
+                    showTooltip($input, 'error', __('This is not a valid answer'));
+                }
             }
         };
 

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -132,7 +132,7 @@ var render = function render(interaction) {
 
             hideTooltip($input);
 
-            if (regex.test($input.val())) {
+            if ($input.val().length && regex.test($input.val())) {
                 $input.removeClass('invalid');
             } else {
                 $input.addClass('invalid');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -128,11 +128,13 @@ var render = function render(interaction) {
             });
     } else if (attributes.patternMask) {
         updatePatternMaskTooltip = function updatePatternMaskTooltip() {
+            if (!$input.val().length) return;
+
             var regex = new RegExp(attributes.patternMask);
 
             hideTooltip($input);
 
-            if ($input.val().length && regex.test($input.val())) {
+            if (regex.test($input.val())) {
                 $input.removeClass('invalid');
             } else {
                 $input.addClass('invalid');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -128,9 +128,9 @@ var render = function render(interaction) {
             });
     } else if (attributes.patternMask) {
         updatePatternMaskTooltip = function updatePatternMaskTooltip() {
-            if (!$input.val().length) return;
-
             var regex = new RegExp(attributes.patternMask);
+
+            if (!$input.val().length) return;
 
             hideTooltip($input);
 

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -139,7 +139,7 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.ok(getTooltip($input).not(':visible'), 'the tooltip error is not hidden after a correct response');
+                assert.ok(getTooltip($input).not(':visible'), 'the error tooltip is hidden in a correct response');
 
                 $input.val('PARIS');
                 $input.keyup();
@@ -147,7 +147,7 @@ define([
             })
             .on('responsechange', function(state) {
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
-                assert.ok(getTooltip($input).not(':visible'), 'the tooltip error is not hidden after a correct response');
+                assert.ok(getTooltip($input).not(':visible'), 'the error tooltip is hidden in a correct response');
                 ready();
             })
             .init()

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -28,12 +28,19 @@ define([
         }
     }
 
+    function hasTooltip($input) {
+        return getTooltipText($input) || false;
+    }
+
     function getTooltip($input) {
-        var instance = $input.data('$tooltip');
+        var instance = getTooltipText($input)
         if (instance && instance.popperInstance.popper) {
             return $(instance.popperInstance.popper);
         }
-        return instance
+    }
+
+    function getTooltipText($input) {
+        return $input.data('$tooltip');
     }
 
     QUnit.test('Lenght constraint', function(assert) {
@@ -140,7 +147,7 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.ok(!getTooltip($input), 'the error tooltip is hidden in a correct response');
+                assert.ok(!hasTooltip($input), 'the error tooltip is hidden in a correct response');
 
                 $input.val('PARIS');
                 $input.keyup();
@@ -148,7 +155,7 @@ define([
             })
             .on('responsechange', function(state) {
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
-                assert.ok(!getTooltip($input), 'the error tooltip is hidden in a correct response');
+                assert.ok(!hasTooltip($input), 'the error tooltip is hidden in a correct response');
                 ready();
             })
             .init()

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -141,6 +141,10 @@ define([
                     'the container contains a text entry interaction .qti-textEntryInteraction'
                 );
 
+                $input.val('');
+                $input.focus();
+                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
+
                 $input.val('PARIS');
                 $input.keyup();
                 ready();
@@ -149,7 +153,7 @@ define([
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
                 assert.equal(
                     getTooltipContent($input),
-                    undefined,
+                    __('This is not a valid answer'),
                     'the error tooltip is hidden after a correct response'
                 );
                 ready();

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -33,6 +33,7 @@ define([
         if (instance && instance.popperInstance.popper) {
             return $(instance.popperInstance.popper);
         }
+        return instance
     }
 
     QUnit.test('Lenght constraint', function(assert) {
@@ -54,12 +55,7 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.equal(
-                    getTooltipContent($input),
-                    __('%d characters allowed', 5),
-                    'the instruction message is correct'
-                );
-                assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
+                assert.ok(!getTooltip($input), 'tooltip is hidden when no length');
 
                 $input.val('123');
                 $input.keyup();
@@ -139,7 +135,7 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.ok(getTooltip($input).not(':visible'), 'the error tooltip is hidden in a correct response');
+                assert.ok(!getTooltip($input), 'the error tooltip is hidden in a correct response');
 
                 $input.val('PARIS');
                 $input.keyup();
@@ -147,7 +143,7 @@ define([
             })
             .on('responsechange', function(state) {
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
-                assert.ok(getTooltip($input).not(':visible'), 'the error tooltip is hidden in a correct response');
+                assert.ok(!getTooltip($input), 'the error tooltip is hidden in a correct response');
                 ready();
             })
             .init()

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -101,10 +101,6 @@ define([
                     'the container contains a text entry interaction .qti-textEntryInteraction'
                 );
 
-                $input.val('');
-                $input.focus();
-                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
-
                 $input.val('123');
                 $input.keyup();
                 ready();
@@ -140,10 +136,6 @@ define([
                     1,
                     'the container contains a text entry interaction .qti-textEntryInteraction'
                 );
-
-                $input.val('');
-                $input.focus();
-                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
 
                 $input.val('PARIS');
                 $input.keyup();

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -55,7 +55,12 @@ define([
 
                 $input.val('');
                 $input.focus();
-                assert.ok(!getTooltip($input), 'tooltip is hidden when no length');
+                assert.equal(
+                    getTooltipContent($input),
+                    __('%d characters allowed', 5),
+                    'the instruction message is correct'
+                );
+                assert.ok(getTooltip($input).is(':visible'), 'info tooltip is visible');
 
                 $input.val('123');
                 $input.keyup();

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -101,6 +101,10 @@ define([
                     'the container contains a text entry interaction .qti-textEntryInteraction'
                 );
 
+                $input.val('');
+                $input.focus();
+                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
+
                 $input.val('123');
                 $input.keyup();
                 ready();
@@ -145,7 +149,7 @@ define([
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
                 assert.equal(
                     getTooltipContent($input),
-                    __('This is not a valid answer'),
+                    undefined,
                     'the error tooltip is hidden after a correct response'
                 );
                 ready();

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -101,10 +101,6 @@ define([
                     'the container contains a text entry interaction .qti-textEntryInteraction'
                 );
 
-                $input.val('');
-                $input.focus();
-                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
-
                 $input.val('123');
                 $input.keyup();
                 ready();
@@ -141,10 +137,6 @@ define([
                     'the container contains a text entry interaction .qti-textEntryInteraction'
                 );
 
-                $input.val('');
-                $input.focus();
-                assert.equal(getTooltipContent($input), __('This is not a valid answer'));
-
                 $input.val('PARIS');
                 $input.keyup();
                 ready();
@@ -153,7 +145,7 @@ define([
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
                 assert.equal(
                     getTooltipContent($input),
-                    __('This is not a valid answer'),
+                    undefined,
                     'the error tooltip is hidden after a correct response'
                 );
                 ready();

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -137,17 +137,17 @@ define([
                     'the container contains a text entry interaction .qti-textEntryInteraction'
                 );
 
+                $input.val('');
+                $input.focus();
+                assert.ok(getTooltip($input).not(':visible'), 'the tooltip error is not hidden after a correct response');
+
                 $input.val('PARIS');
                 $input.keyup();
                 ready();
             })
             .on('responsechange', function(state) {
                 var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
-                assert.equal(
-                    getTooltipContent($input),
-                    undefined,
-                    'the error tooltip is hidden after a correct response'
-                );
+                assert.ok(getTooltip($input).not(':visible'), 'the tooltip error is not hidden after a correct response');
                 ready();
             })
             .init()


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/BSA-36

**Fix other cases not covered by**

https://github.com/oat-sa/extension-tao-itemqti/pull/1426

**Other necessary PR to be merged for seeing complete feature working**

https://github.com/oat-sa/extension-tao-itemqti/pull/1436

**Description**

Avoid error message appears in any case before the user write something

**AC**

- [x] Message error only appears after user write something **AND** don't fit pattern mask
