### PR TITLE
Fix/tao 10178/extended text interaction xhtml check patter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.20",
+    "version": "0.4.21",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.20",
+    "version": "0.4.21",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -434,7 +434,7 @@ var inputLimiter = function userInputLimier(interaction) {
                 if (patternRegEx) {
                     if (isCke) {
                         // cke has its own object structure
-                        newValue = e.getData();
+                        newValue = this.getData();
                     } else {
                         // covers input
                         newValue = e.currentTarget.value;
@@ -552,6 +552,7 @@ var inputLimiter = function userInputLimier(interaction) {
             if (_getFormat(interaction) === 'xhtml') {
                 cke = _getCKEditor(interaction);
                 cke.on('key', keyLimitHandler);
+                cke.on('change', patternHandler);
                 cke.on('paste', nonKeyLimitHandler);
                 // @todo: drop requires cke 4.5
                 // cke.on('drop', nonKeyLimitHandler);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-10178

Added checking pattern for XHTML format in Extended text Interaction.

How to test:

1. Create an item with Extended text Interaction.
2. In Interaction properties select Pattern constraint and set pattern ^[A-z]{2,}$.
3. Choose Format XHTML.
4. Save and Preview.
5. In Preview type some digits in response section (f.e. 123).
6. Expected result: 'This is not a valid answer' message should appear when typed text is violating Pattern constraint