### PR TITLE
Fix/tbd 22/clean up responsive image style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/img.tpl
+++ b/src/qtiCommonRenderer/tpl/img.tpl
@@ -8,5 +8,9 @@
     {{#if attributes.height}}height="{{attributes.height}}" {{/if}}
     {{#if attributes.width}}width="{{attributes.width}}" {{/if}}
     {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
-    style="{{#if attributes.height}}height: {{attributes.height}}px; {{#if attributes.width}}width: {{attributes.width}}px; {{/if}}{{/if}}"
+    {{#if attributes.height}}
+        style="height: {{attributes.height}}px; width: {{attributes.width}}px;"
+        {{else}}
+        style="width: {{attributes.width}};"
+    {{/if}}
     />

--- a/src/qtiCommonRenderer/tpl/img.tpl
+++ b/src/qtiCommonRenderer/tpl/img.tpl
@@ -8,5 +8,5 @@
     {{#if attributes.height}}height="{{attributes.height}}" {{/if}}
     {{#if attributes.width}}width="{{attributes.width}}" {{/if}}
     {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
-    style="{{#if attributes.height}}height: {{attributes.height}}px; {{/if}}{{#if attributes.width}}width: {{attributes.width}}px; {{/if}}"
+    style="{{#if attributes.height}}height: {{attributes.height}}px; {{#if attributes.width}}width: {{attributes.width}}px; {{/if}}{{/if}}"
     />


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TBD-22

QTI runner renders a responsive image with a redundant style: width=<n>, that should be removed, as the image's width is being controlled by a width attribute.
Before fix
![image](https://user-images.githubusercontent.com/25976342/81152370-8fdb6380-8f8a-11ea-8ead-7f350a104ced.png)
After fix
![image](https://user-images.githubusercontent.com/25976342/81152564-bb5e4e00-8f8a-11ea-85ff-1a370d0db6cd.png)

How to test:

1. create an item with an image
2. set a responsive mode for image
3. preview image and check tag style
