### PR TITLE
media interaction for review mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/reviewRenderer/renderers/config.js
+++ b/src/reviewRenderer/renderers/config.js
@@ -98,6 +98,7 @@ const locations = {
     graphicGapMatchInteraction: 'taoQtiItem/reviewRenderer/renderers/interactions/GraphicGapMatchInteraction',
     uploadInteraction: 'taoQtiItem/reviewRenderer/renderers/interactions/UploadInteraction',
     customInteraction: 'taoQtiItem/reviewRenderer/renderers/interactions/PortableCustomInteraction',
+    mediaInteraction: 'taoQtiItem/reviewRenderer/renderers/interactions/MediaInteraction',
 
     // Interactions/Choices inherited from qtiCommonRenderer
 
@@ -108,7 +109,6 @@ const locations = {
         'taoQtiItem/qtiCommonRenderer/renderers/choices/SimpleAssociableChoice.MatchInteraction',
     'simpleAssociableChoice.associateInteraction':
         'taoQtiItem/qtiCommonRenderer/renderers/choices/SimpleAssociableChoice.AssociateInteraction',
-    mediaInteraction: 'taoQtiItem/qtiCommonRenderer/renderers/interactions/MediaInteraction',
     gapImg: 'taoQtiItem/qtiCommonRenderer/renderers/choices/GapImg',
     endAttemptInteraction: 'taoQtiItem/qtiCommonRenderer/renderers/interactions/EndAttemptInteraction',
 };

--- a/src/reviewRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/MediaInteraction.js
@@ -1,0 +1,138 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+/**
+ * @author Ansul Sharma <ansultaotesting.com>
+ */
+import $ from 'jquery';
+import _ from 'lodash';
+import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
+import mediaInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/MediaInteraction';
+import mediaplayer from 'ui/mediaplayer';
+
+var defaults = {
+    type: 'video/mp4',
+    video: {
+        height: 270
+    }
+};
+
+/**
+ * Init rendering, called after template injected into the DOM
+ * All options are listed in the QTI v2.1 information model:
+ * http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10391
+ *
+ * @param {object} interaction
+ * @returns {Promise<any>}
+ */
+var render = function render(interaction) {
+    return new Promise((resolve) => {
+        var $container = containerHelper.get(interaction);
+        var media = interaction.object;
+        var $item = $container.parents('.qti-item');
+        var url = media.attr('data') || '';
+
+        /**
+         * Resize video player elements to fit container size
+         * @param {Object} mediaElement - player instance
+         * @param {jQueryElement} $container   - container element to adapt
+         */
+        var resize = _.debounce(function resize() {
+            var width, height;
+            if (interaction.mediaElement) {
+                height = $container.find('.media-container').height();
+                width = $container.find('.media-container').width();
+
+                interaction.mediaElement.resize(width, height);
+            }
+        }, 200);
+
+        //intialize the player if not yet done
+        const initMediaPlayer = () => {
+            if (!interaction.mediaElement) {
+                interaction.mediaElement = mediaplayer({
+                    url: url && this.resolveUrl(url),
+                    type: media.attr('type') || defaults.type,
+                    canPause: true,
+                    canSeek: true,
+                    width: media.attr('width'),
+                    height: media.attr('height'),
+                    autoStart: false,
+                    loop: false,
+                    renderTo: $('.media-container', $container)
+                })
+                    .on('render', function() {
+                        resize();
+
+                        $(window)
+                            .off('resize.mediaInteraction')
+                            .on('resize.mediaInteraction', resize);
+
+                        $item.off('resize.gridEdit').on('resize.gridEdit', resize);
+
+                        /**
+                         * @event playerrendered
+                         */
+                        $container.trigger('playerrendered');
+                    })
+                    .on('ready', function() {
+                        /**
+                         * @event playerready
+                         */
+                        $container.trigger('playerready');
+
+                        // declare the item ready when player is ready to play.
+                        resolve();
+                    })
+                    .on(
+                        'update',
+                        _.throttle(function() {
+                            containerHelper.triggerResponseChangeEvent(interaction);
+                        }, 1000)
+                    )
+                    .on('ended', function() {
+                        containerHelper.triggerResponseChangeEvent(interaction);
+                    });
+            }
+        };
+
+        if (_.size(media.attributes) === 0) {
+            //TODO move to afterCreate
+            media.attr('type', defaults.type);
+            media.attr('width', $container.innerWidth());
+
+            media.attr('height', defaults.video.height);
+            media.attr('data', '');
+        }
+
+        //initialize the component
+        $container.on('responseSet', function() {
+            initMediaPlayer();
+        });
+
+        //gives a small chance to the responseSet event before initializing the player
+        initMediaPlayer();
+    });
+};
+
+/**
+ * Expose the common renderer for the match interaction
+ * @exports reviewRenderer/renderers/interactions/MatchInteraction
+ */
+export default Object.assign({}, mediaInteraction, {render});

--- a/src/reviewRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/MediaInteraction.js
@@ -51,13 +51,11 @@ const render = function render(interaction) {
         /**
          * Resize video player elements to fit container size
          * @param {Object} mediaElement - player instance
-         * @param {jQueryElement} $container   - container element to adapt
          */
         const resize = _.debounce(() => {
-            let width, height;
             if (interaction.mediaElement) {
-                height = $container.find('.media-container').height();
-                width = $container.find('.media-container').width();
+                const height = $container.find('.media-container').height();
+                const width = $container.find('.media-container').width();
 
                 interaction.mediaElement.resize(width, height);
             }

--- a/src/reviewRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/MediaInteraction.js
@@ -132,7 +132,7 @@ var render = function render(interaction) {
 };
 
 /**
- * Expose the common renderer for the match interaction
- * @exports reviewRenderer/renderers/interactions/MatchInteraction
+ * Expose the common renderer for the media interaction
+ * @exports reviewRenderer/renderers/interactions/mediaInteraction
  */
 export default Object.assign({}, mediaInteraction, {render});

--- a/src/reviewRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/MediaInteraction.js
@@ -26,7 +26,7 @@ import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import mediaInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/MediaInteraction';
 import mediaplayer from 'ui/mediaplayer';
 
-var defaults = {
+const defaults = {
     type: 'video/mp4',
     video: {
         height: 270
@@ -41,20 +41,20 @@ var defaults = {
  * @param {object} interaction
  * @returns {Promise<any>}
  */
-var render = function render(interaction) {
+const render = function render(interaction) {
     return new Promise((resolve) => {
-        var $container = containerHelper.get(interaction);
-        var media = interaction.object;
-        var $item = $container.parents('.qti-item');
-        var url = media.attr('data') || '';
+        const $container = containerHelper.get(interaction);
+        const media = interaction.object;
+        const $item = $container.parents('.qti-item');
+        const url = media.attr('data') || '';
 
         /**
          * Resize video player elements to fit container size
          * @param {Object} mediaElement - player instance
          * @param {jQueryElement} $container   - container element to adapt
          */
-        var resize = _.debounce(function resize() {
-            var width, height;
+        const resize = _.debounce(() => {
+            let width, height;
             if (interaction.mediaElement) {
                 height = $container.find('.media-container').height();
                 width = $container.find('.media-container').width();
@@ -77,7 +77,7 @@ var render = function render(interaction) {
                     loop: false,
                     renderTo: $('.media-container', $container)
                 })
-                    .on('render', function() {
+                    .on('render', () => {
                         resize();
 
                         $(window)
@@ -91,7 +91,7 @@ var render = function render(interaction) {
                          */
                         $container.trigger('playerrendered');
                     })
-                    .on('ready', function() {
+                    .on('ready', () => {
                         /**
                          * @event playerready
                          */
@@ -102,11 +102,11 @@ var render = function render(interaction) {
                     })
                     .on(
                         'update',
-                        _.throttle(function() {
+                        _.throttle(() => {
                             containerHelper.triggerResponseChangeEvent(interaction);
                         }, 1000)
                     )
-                    .on('ended', function() {
+                    .on('ended', () => {
                         containerHelper.triggerResponseChangeEvent(interaction);
                     });
             }
@@ -122,7 +122,7 @@ var render = function render(interaction) {
         }
 
         //initialize the component
-        $container.on('responseSet', function() {
+        $container.on('responseSet', () => {
             initMediaPlayer();
         });
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-137

### What has changed?

* Media interaction in review Renderer now has different settings to make the user experience of scorer better. Every media interaction will have the following settings regardless of what is set in authoring for test-taker:

- Can be player infinite times
- Can pause
- Can seek
- autoplay: false
- volume: 80 (Max is 100)
- loop: false

#### Related PRs:

- https://github.com/oat-sa/extension-tao-itemqti/pull/1451

### How to test?

- Checkout this branch in tao-item-qti: `feature/MS-147/enhanced-readonly-mode`
- Install node modules in tao-item-qti
- Create an item with media interactions and add some restrictions (can be played only once, cant pause, etc)
- Preview the item, you should see it as expected and restrictions should be respected
- Take the test, you should again see the media player as expected and restrictions should be respected
- Now, view the result of the test you submitted by ltiOutcomeUi (this uses reviewRenderer)
- You should be able to interact with the media interaction and you should not have any restrictions. You should be able to play/pause, seek, increase/decrease volume and replay the media as many times as you like.

### Checklist:

- [ ] Merge this PR and publish package
- [ ] Change dependency version here and merge this PR: https://github.com/oat-sa/extension-tao-itemqti/pull/1451