### PR TITLE
Release 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -492,7 +492,9 @@ var inputLimiter = function userInputLimier(interaction) {
                 var oldValue = _getTextareaValue(interaction);
                 var isCke = _getFormat(interaction) === 'xhtml';
 
-                if (isCke) {
+                if (typeof($(e.target).attr('data-clipboard')) === 'string') {
+                    newValue = $(e.target).attr('data-clipboard');
+                } else if (isCke) {
                     // cke has its own object structure
                     newValue = e.data.dataValue;
                 } else {


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-519
 
Update extended text interaction to take content from data-clipboard if it available when handling copy event
 
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery which includes extended text interaction with some constraints
- enable security mode for the delivery
- execute the delivery as a test taker and try to copy/paste to the text interaction
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/159