### PR TITLE
Hotfix/tao 10178/extended text interaction xhtml check patter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.4",
+    "version": "0.4.4-1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1232,11 +1232,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-            "dev": true
-        },
-        "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
             "dev": true
         },
         "external-editor": {
@@ -2793,8 +2788,11 @@
             "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.1.4.tgz",
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
-            "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+            "dependencies": {
+                "eve": {
+                    "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+                    "from": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+                }
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.4.4",
+    "version": "0.4.4-1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -430,7 +430,7 @@ var inputLimiter = function userInputLimier(interaction) {
                 if (patternRegEx) {
                     if (isCke) {
                         // cke has its own object structure
-                        newValue = e.getData();
+                        newValue = this.getData();
                     } else {
                         // covers input
                         newValue = e.currentTarget.value;
@@ -537,6 +537,7 @@ var inputLimiter = function userInputLimier(interaction) {
             if (_getFormat(interaction) === 'xhtml') {
                 cke = _getCKEditor(interaction);
                 cke.on('key', keyLimitHandler);
+                cke.on('change', patternHandler);
                 cke.on('paste', nonKeyLimitHandler);
                 // @todo: drop requires cke 4.5
                 // cke.on('drop', nonKeyLimitHandler);


### PR DESCRIPTION
Backport https://github.com/oat-sa/tao-item-runner-qti-fe/pull/67
Related to: https://oat-sa.atlassian.net/browse/TAO-10178
Added checking pattern for XHTML format in Extended text Interaction.

How to test:

1. Create an item with Extended text Interaction.
2. In Interaction properties select Pattern constraint and set pattern ^[A-z]{2,}$.
3. Choose Format XHTML.
4. Save and Preview.
5. In Preview type some digits in response section (f.e. 123).
6. Expected result: 'This is not a valid answer' message should appear when typed text is violating Pattern constraint