### PR TITLE
[TCA-638] Adjusting template to include ARIA attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/img.tpl
+++ b/src/qtiCommonRenderer/tpl/img.tpl
@@ -1,8 +1,8 @@
-<img 
-    data-serial="{{serial}}" 
-    data-qti-class="img" 
-    src="{{attributes.src}}" 
-    alt="{{attributes.alt}}" 
+<img
+    data-serial="{{serial}}"
+    data-qti-class="img"
+    src="{{attributes.src}}"
+    alt="{{attributes.alt}}"
     {{#if attributes.id}}id="{{attributes.id}}"{{/if}}
     {{#if attributes.class}}class="{{attributes.class}}"{{/if}}
     {{#if attributes.height}}height="{{attributes.height}}" {{/if}}
@@ -13,4 +13,10 @@
         {{else}}
         style="width: {{attributes.width}};"
     {{/if}}
+    {{#if attributes.[aria-describedby]}} aria-describedby="{{attributes.[aria-describedby]}}"{{/if}}
+    {{#if attributes.[aria-hidden]}} aria-hidden="{{attributes.[aria-hidden]}}"{{/if}}
+    {{#if attributes.[aria-label]}} aria-label="{{attributes.[aria-label]}}"{{/if}}
+    {{#if attributes.[aria-labelledby]}} aria-labelledby="{{attributes.[aria-labelledby]}}"{{/if}}
+    {{#if attributes.[aria-live]}} aria-live="{{attributes.[aria-live]}}"{{/if}}
+    {{#if attributes.role}} role="{{attributes.role}}"{{/if}}
     />


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-638
 
Apply aria attributes to images
  
#### How to test
 
- prepare an instance of TAO
- import test assigned to https://oat-sa.atlassian.net/browse/TCA-604
- executed delivery created from test as a test taker
- make sure that aria attributes are in place
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1464