### PR TITLE
Fix TAO 10122 - Error navigation gap interaction question

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/GraphicGapMatchInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/GraphicGapMatchInteraction.js
@@ -602,11 +602,24 @@ var setResponse = function(interaction, response) {
  *
  * @param {object} interaction
  */
+
+function msieversion() {
+    var ua = window.navigator.userAgent;
+    var msie = ua.indexOf('MSIE ');
+
+    if (msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./)) {
+        return true;
+    }
+    return false;
+}
+
 var resetResponse = function resetResponse(interaction) {
     _shapesUnSelectable(interaction);
 
     _.forEach(interaction.gapFillers, function(gapFiller) {
-        interactUtils.tapOn(gapFiller.items[2][0]); // this refers to the gapFiller image
+        if (!msieversion()) {
+            interactUtils.tapOn(gapFiller.items[2][0]); // this refers to the gapFiller image
+        }
     });
 };
 


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/TAO-10122

**Description**

InternetExplorer: Have created a Graphic Gap interactions with images and matched them in response
When I do different actions with functionality, at some point, I can't seem to edit the size of the "Gap match slots" 
I am not experiencing the same problems in f.eks Chrome

Workaround: Click outside the interaction and try again

**How to test it**

- Add graphic 'Gap match' interaction to the canvas in the Internet Explorer browser
- Select a file and click 'Select'
- Click the "Plus in circle" icon
- Select `file` and click 'Select' 
- Click 'Response' and set the added picture to the gap 
-  Click 'Question' and find media sizer in the Interaction properties panel

**Experienced Behavior**

The interaction properties panel is missing.

**Expected Behavior**

The interaction properties panel is displayed as soon as 'Question' is clicked in interaction.