### PR TITLE
[TCA-737] Screen Reader : Answer options announced multiple times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
@@ -7,7 +7,6 @@
                 name="response-{{interaction.serial}}"
                 value="{{attributes.identifier}}"
                 tabindex="1"
-                aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}"
             >
             <span class="icon-radio"></span>
             {{else}}
@@ -16,13 +15,12 @@
                 name="response-{{interaction.serial}}"
                 value="{{attributes.identifier}}"
                 tabindex="1"
-                aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}"
             >
             <span class="icon-checkbox"></span>
             {{/if}}
         </label>
         <div class="label-box">
-            <div aria-hidden="true" class="label-content clear" contenteditable="false" id="choice-{{interaction.serial}}-{{attributes.identifier}}">
+            <div class="label-content clear" contenteditable="false" id="choice-{{interaction.serial}}-{{attributes.identifier}}">
                 {{{body}}}
                 <svg class="overlay-answer-eliminator">
                     <line x1="0" y1="100%" x2="100%" y2="0"/>

--- a/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
@@ -22,7 +22,7 @@
             {{/if}}
         </label>
         <div class="label-box">
-            <div class="label-content clear" contenteditable="false" id="choice-{{interaction.serial}}-{{attributes.identifier}}">
+            <div aria-hidden="true" class="label-content clear" contenteditable="false" id="choice-{{interaction.serial}}-{{attributes.identifier}}">
                 {{{body}}}
                 <svg class="overlay-answer-eliminator">
                     <line x1="0" y1="100%" x2="100%" y2="0"/>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-737
  
remove `aria-labelledby` attribute from simple choice interaction
 
#### How to test:

- prepare an instance of TAO with taoAct extension
- prepare a delivery with choice interaction and accessibility mode enabled
- execute delivery as a test taker
- make sure that choice items do not have `aria-labelledby` attribute
 
#### Dependencies

Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/291
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1500
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1883