### PR TITLE
Release 0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
@@ -7,7 +7,6 @@
                 name="response-{{interaction.serial}}"
                 value="{{attributes.identifier}}"
                 tabindex="1"
-                aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}"
             >
             <span class="icon-radio"></span>
             {{else}}
@@ -16,7 +15,6 @@
                 name="response-{{interaction.serial}}"
                 value="{{attributes.identifier}}"
                 tabindex="1"
-                aria-labelledby="choice-{{interaction.serial}}-{{attributes.identifier}}"
             >
             <span class="icon-checkbox"></span>
             {{/if}}


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-737
  
remove `aria-labelledby` attribute from simple choice interaction
 
#### How to test:

- prepare an instance of TAO with taoAct extension
- prepare a delivery with choice interaction and accessibility mode enabled
- execute delivery as a test taker
- make sure that choice items do not have `aria-labelledby` attribute
 
#### Dependencies

Companion PR :
 - [ ] https://github.com/oat-sa/tao-test-runner-qti-fe/pull/291
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1500
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1883