### PR TITLE
[CTCA-154] Screen Reader : Character count has an unusual abbreviation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/interactions/extendedTextInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/extendedTextInteraction.tpl
@@ -29,12 +29,12 @@
     {{/if}}
     <div class="text-counter">
         {{#if attributes.expectedLength}}
-            <span class="count-chars">0</span> {{__ "of"}} <span class="count-expected-length">{{attributes.expectedLength}}</span> {{__ "chars"}} {{__ "recommended"}}.
+            <span class="count-chars">0</span> {{__ "of"}} <span class="count-expected-length">{{attributes.expectedLength}}</span> {{__ "characters"}} {{__ "recommended"}}.
         {{else}}
             {{#if maxLength}}
-                <span class="text-counter-chars"><span class="count-chars">0</span> {{__ "of"}} <span class="count-max-length">{{maxLength}}</span> {{__ "chars"}} {{__ "maximum"}}.</span>
+                <span class="text-counter-chars"><span class="count-chars">0</span> {{__ "of"}} <span class="count-max-length">{{maxLength}}</span> {{__ "characters"}} {{__ "maximum"}}.</span>
             {{else}}
-                <span class="text-counter-chars" style="display: none"><span class="count-chars">0</span> {{__ "of"}} <span class="count-max-length">{{maxLength}}</span> {{__ "chars"}} {{__ "maximum"}}.</span>
+                <span class="text-counter-chars" style="display: none"><span class="count-chars">0</span> {{__ "of"}} <span class="count-max-length">{{maxLength}}</span> {{__ "characters"}} {{__ "maximum"}}.</span>
             {{/if}}
             {{#if maxWords}}
                 <span class="text-counter-words"><span class="count-words">0</span> {{__ "of"}} <span class="count-max-words">{{maxWords}}</span> {{__ "words"}} {{__ "maximum"}}.</span>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/CTCA-154
 
Change label chars to characters in text interactions constraints label
  
#### How to test

- prepare an instance of TAO
- prepare a delivery with text interactions which contains some constraints
- execute delivery as a test taker
- check that constraints label contains `characters` instead of `chars`
 
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1507