### PR TITLE
Feature UNO 467 - Extend Response Properties on text Entry interaction with possibility to set baseType property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.3",
+    "version": "0.11.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.3",
+    "version": "0.11.0",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -81,13 +81,11 @@ var render = function render(interaction) {
         maxChars = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10);
 
     // Setting up baseType
-    if (baseType) {
         if (baseType === 'integer') {
             $input.attr('inputmode', 'numeric');
         } else if (baseType === 'float') {
             $input.attr('inputmode', 'decimal');
         }
-    }
 
     //setting up the width of the input field
     if (attributes.expectedLength) {

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -72,6 +72,7 @@ var showTooltip = function showTooltip($input, theme, message) {
  */
 var render = function render(interaction) {
     var attributes = interaction.getAttributes(),
+        baseType = interaction.getResponseDeclaration().attributes.baseType,
         $input = interaction.getContainer(),
         expectedLength,
         updateMaxCharsTooltip,
@@ -79,13 +80,13 @@ var render = function render(interaction) {
         patternMask = interaction.attr('patternMask'),
         maxChars = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10);
 
-    attributes.baseType = 'integer';
+    // baseType = 'float';
 
     // Setting up baseType
-    if (attributes.baseType) {
-        if (attributes.baseType === 'integer') {
+    if (baseType) {
+        if (baseType === 'integer') {
             $input.attr('inputmode', 'numeric');
-        } else if (attributes.baseType === 'float') {
+        } else if (baseType === 'float') {
             $input.attr('inputmode', 'decimal');
         }
     }

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -79,6 +79,17 @@ var render = function render(interaction) {
         patternMask = interaction.attr('patternMask'),
         maxChars = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10);
 
+    attributes.baseType = 'integer';
+
+    // Setting up baseType
+    if (attributes.baseType) {
+        if (attributes.baseType === 'integer') {
+            $input.attr('inputmode', 'numeric');
+        } else if (attributes.baseType === 'float') {
+            $input.attr('inputmode', 'decimal');
+        }
+    }
+
     //setting up the width of the input field
     if (attributes.expectedLength) {
         //adding 2 chars to include reasonable padding size

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -80,8 +80,6 @@ var render = function render(interaction) {
         patternMask = interaction.attr('patternMask'),
         maxChars = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10);
 
-    // baseType = 'float';
-
     // Setting up baseType
     if (baseType) {
         if (baseType === 'integer') {

--- a/src/qtiCommonRenderer/tpl/interactions/textEntryInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/textEntryInteraction.tpl
@@ -1,1 +1,7 @@
-<input {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-inlineInteraction qti-textEntryInteraction{{#if attributes.class}} {{attributes.class}}{{/if}}" data-serial="{{serial}}" data-qti-class="textEntryInteraction" type="text">
+<input
+        {{#if attributes.id}}id="{{attributes.id}}"{{/if}}
+        class="qti-interaction qti-inlineInteraction qti-textEntryInteraction{{#if attributes.class}} {{attributes.class}}{{/if}}"
+        data-serial="{{serial}}"
+        data-qti-class="textEntryInteraction"
+        type="text"
+>


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/UNO-467

**Description**

**As** content creator
**I would** like during the assessment on textEntry interaction and in case of touch-based devices, to open the numeric keyboard for input
**so that**  we increase user experience and eliminate possibilities for wrong input

**Acceptance Criteria**

**AC1**

**GIVEN** an inline `textEntry` interaction flagged as expecting a numeric input
**WHEN** the test taker tap on the input field with a touch-based device like a tablet
**THEN** the device opens the numeric keyboard instead of the alphanumeric keyboard

**Considerations**

The main goal is to implement this story on the NextGen test runner.

- NextGen test runner

Implementation of NextGen test runner already support such behavior.  We have to add inputmode=numeric if the `baseType` is integer and `inputmode=decimal` if the `baseType` is a `float`

- CurrentGen test runner

Implementation for CurrentGen test runner implement similar logic as on NextGen test runner relying on `inputmode`

**How to Test**

**Requires touch-based device, tablet or similar**

Create an item with `textEntry` interaction with Response `baseType` declaration set to integer or float.

Create a test including the item(s) created before and publish to NextGen to deliver an environment that is linked with New Test runner ex.

on demo.udir publish on using tenant: UDIR QA (new Test Runner)

Launch delivery execution from the touch-based device

Verify during input on textEntry interaction with numeric `baseType`,  numeric keyboard is rendered.