### PR TITLE
[Fix] UNO 467 - Support correct version for default on render numerical input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.12.0",
+    "version": "0.11.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.11.1",
+    "version": "0.12.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.11.1",
+    "version": "0.12.0",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.12.0",
+    "version": "0.11.3",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -86,6 +86,8 @@ var render = function render(interaction) {
             $input.attr('inputmode', 'numeric');
         } else if (baseType === 'float') {
             $input.attr('inputmode', 'decimal');
+        } else {
+            $input.attr('inputmode', 'text');
         }
     }
 

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -81,14 +81,15 @@ var render = function render(interaction) {
         maxChars = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10);
 
     // Setting up baseType
-    if (baseType) {
-        if (baseType === 'integer') {
+    switch (baseType) {
+        case 'integer':
             $input.attr('inputmode', 'numeric');
-        } else if (baseType === 'float') {
+            break;
+        case 'float':
             $input.attr('inputmode', 'decimal');
-        } else {
+            break;
+        default:
             $input.attr('inputmode', 'text');
-        }
     }
 
     //setting up the width of the input field

--- a/test/qtiCommonRenderer/interactions/textEntry/test.html
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.html
@@ -21,6 +21,7 @@
             <div id="fixture-length-constraint"></div>
             <div id="pattern-constraint-incorrect"></div>
             <div id="pattern-constraint-correct"></div>
+            <div id="pattern-constraint-inputmode"></div>
             <div id="set-get-response"></div>
         </div>
 

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -213,16 +213,16 @@ define([
             assert.equal($container.length, 1, 'the item container exists');
             assert.equal($container.children().length, 0, 'the container has no children');
             renderMatchInteraction($container, item)
-                .then(() => {
+                .then(itemRunner => {
                     const $input = $container.find('.qti-interaction.qti-textEntryInteraction');
-
-                    console.log($input.attr('inputmode'), $input);
 
                     assert.equal(
                         $input.attr('inputmode'),
                         data.expected,
                         data.title
                     );
+                    
+                    itemRunner.clear();
                 })
                 .catch(err => {
                     assert.pushResult({

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -5,8 +5,22 @@ define([
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/text-entry-noconstraint.json',
     'json!taoQtiItem/test/samples/json/text-entry-length.json',
-    'json!taoQtiItem/test/samples/json/text-entry-pattern.json'
-], function($, _, __, qtiItemRunner, textEntryData, textEntryLengthConstrainedData, textEntryPatternConstrainedData) {
+    'json!taoQtiItem/test/samples/json/text-entry-pattern.json',
+    'json!taoQtiItem/test/samples/json/text-entry-inputmode-text.json',
+    'json!taoQtiItem/test/samples/json/text-entry-inputmode-integer.json',
+    'json!taoQtiItem/test/samples/json/text-entry-inputmode-float.json'
+], function(
+    $,
+    _,
+    __,
+    qtiItemRunner,
+    textEntryData,
+    textEntryLengthConstrainedData,
+    textEntryPatternConstrainedData,
+    textEntryInputmodeTextData,
+    textEntryInputmodeIntegerData,
+    textEntryInputmodeFloatData
+) {
     'use strict';
 
     var runner;
@@ -175,31 +189,37 @@ define([
     QUnit.cases
         .init([
             {
-                baseType: 'text',
+                title: 'TextEntryInteraction contains inputmode = text',
+                item: textEntryInputmodeTextData,
+                expected: 'text'
             },
             {
-                baseType: 'integer',
+                title: 'TextEntryInteraction contains inputmode = numerical',
+                item: textEntryInputmodeIntegerData,
+                expected: 'numerical'
             },
             {
-                baseType: 'float'
+                title: 'TextEntryInteraction contains inputmode = decimal',
+                item: textEntryInputmodeFloatData,
+                expected: 'decimal'
             }
         ])
         .test('Pattern constraint - inputmode', function(data, assert) {
-            var ready = assert.async();
+            const ready = assert.async();
+            const item = _.cloneDeep(data.item);
 
-            var $container = $('#pattern-constraint-inputmode');
-            textEntryPatternConstrainedData.responses.responseDeclaration.attributes.baseType = data.baseType;
+            const $container = $('#pattern-constraint-inputmode');
 
             assert.equal($container.length, 1, 'the item container exists');
             assert.equal($container.children().length, 0, 'the container has no children');
-            renderMatchInteraction($container, textEntryPatternConstrainedData)
+            renderMatchInteraction($container, item)
                 .then(() => {
                     const $input = $container.find('.qti-interaction.qti-textEntryInteraction');
 
                     assert.equal(
                         $input.attr('inputmode'),
-                        'text',
-                        'TextEntryInteraction contains inputmode = text'
+                        data.expected,
+                        data.title
                     );
                 })
                 .catch(err => {

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -162,6 +162,29 @@ define([
             .render($container);
     });
 
+    QUnit.test('Pattern constraint - inputmode', function(assert) {
+        var ready = assert.async();
+
+        var $container = $('#pattern-constraint-inputmode');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+        runner = qtiItemRunner('qti', textEntryPatternConstrainedData)
+            .on('render', function() {
+                var $input = $container.find('.qti-interaction.qti-textEntryInteraction');
+
+                assert.equal(
+                    $input.attr('inputmode'),
+                    'text',
+                    'TextEntryInteraction contains inputmode = text'
+                );
+
+                ready();
+            })
+            .init()
+            .render($container);
+    });
+
     QUnit.test('set/get response', function(assert) {
         var ready = assert.async();
 

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -221,7 +221,7 @@ define([
                         data.expected,
                         data.title
                     );
-                    
+
                     itemRunner.clear();
                 })
                 .catch(err => {

--- a/test/qtiCommonRenderer/interactions/textEntry/test.js
+++ b/test/qtiCommonRenderer/interactions/textEntry/test.js
@@ -196,7 +196,7 @@ define([
             {
                 title: 'TextEntryInteraction contains inputmode = numerical',
                 item: textEntryInputmodeIntegerData,
-                expected: 'numerical'
+                expected: 'numeric'
             },
             {
                 title: 'TextEntryInteraction contains inputmode = decimal',
@@ -215,6 +215,8 @@ define([
             renderMatchInteraction($container, item)
                 .then(() => {
                     const $input = $container.find('.qti-interaction.qti-textEntryInteraction');
+
+                    console.log($input.attr('inputmode'), $input);
 
                     assert.equal(
                         $input.attr('inputmode'),

--- a/test/samples/json/text-entry-inputmode-float.json
+++ b/test/samples/json/text-entry-inputmode-float.json
@@ -1,0 +1,175 @@
+{
+    "identifier": "i1480079448133120",
+    "serial": "item_583d7ef92da77287593082",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "i1480079448133120",
+        "title": "Item 12",
+        "label": "text interactions",
+        "xml:lang": "it-IT",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "3.2.0-sprint39",
+        "class": ""
+    },
+    "body": {
+        "serial": "container_containeritembody_583d7ef92da59253696663",
+        "body": "\n        <div class=\"grid-row\">\n            <div class=\"col-12\">\n                <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...\u00a0\n\n                    {{interaction_textentryinteraction_583d7ef9340df566552260}} qui street art .\n\n                <\/p>\n            <\/div>\n        <\/div>\n    ",
+        "elements": {
+            "interaction_textentryinteraction_583d7ef9340df566552260": {
+                "serial": "interaction_textentryinteraction_583d7ef9340df566552260",
+                "qtiClass": "textEntryInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE",
+                    "base": 10,
+                    "expectedLength": 8,
+                    "patternMask": "PARIS",
+                    "placeholderText": ""
+                },
+                "debug": {
+                    "relatedItem": "item_583d7ef92da77287593082"
+                },
+                "choices": {}
+            }
+        },
+        "debug": {
+            "relatedItem": "item_583d7ef92da77287593082"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_583d7ef92da77287593082"
+    },
+    "namespaces": {
+        "": "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2",
+        "m": "http:\/\/www.w3.org\/1998\/Math\/MathML",
+        "xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance"
+    },
+    "schemaLocations": {
+        "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2": "http:\/\/www.imsglobal.org\/xsd\/qti\/qtiv2p2\/imsqti_v2p2p1.xsd"
+    },
+    "stylesheets": {
+        "stylesheet_583d7ef93055a662867673": {
+            "serial": "stylesheet_583d7ef93055a662867673",
+            "qtiClass": "stylesheet",
+            "attributes": {
+                "href": "style\/custom\/tao-user-styles.css",
+                "type": "text\/css",
+                "media": "all",
+                "title": ""
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            }
+        }
+    },
+    "outcomes": {
+        "outcomedeclaration_583d7ef932533850568122": {
+            "identifier": "SCORE",
+            "serial": "outcomedeclaration_583d7ef932533850568122",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "SCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            },
+            "defaultValue": null
+        }
+    },
+    "responses": {
+        "responsedeclaration_583d7ef93187a607546486": {
+            "identifier": "RESPONSE",
+            "serial": "responsedeclaration_583d7ef93187a607546486",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "http:\/\/www.imsglobal.org\/question\/qti_v2p1\/rptemplates\/match_correct",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        }
+    },
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_templatesdriven_583d7ef9372b1321065587",
+        "qtiClass": "responseProcessing",
+        "attributes": [],
+        "debug": {
+            "relatedItem": "item_583d7ef92da77287593082"
+        },
+        "processingType": "templateDriven",
+        "responseRules": [
+            {
+                "qtiClass": "responseCondition",
+                "responseIf": {
+                    "qtiClass": "responseIf",
+                    "expression": {
+                        "qtiClass": "match",
+                        "expressions": [
+                            {
+                                "qtiClass": "variable",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            },
+                            {
+                                "qtiClass": "correct",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            }
+                        ]
+                    },
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "1"
+                            }
+                        }
+                    ]
+                },
+                "responseElse": {
+                    "qtiClass": "responseElse",
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "0"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "apipAccessibility": ""
+}

--- a/test/samples/json/text-entry-inputmode-integer.json
+++ b/test/samples/json/text-entry-inputmode-integer.json
@@ -1,0 +1,175 @@
+{
+    "identifier": "i1480079448133120",
+    "serial": "item_583d7ef92da77287593082",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "i1480079448133120",
+        "title": "Item 12",
+        "label": "text interactions",
+        "xml:lang": "it-IT",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "3.2.0-sprint39",
+        "class": ""
+    },
+    "body": {
+        "serial": "container_containeritembody_583d7ef92da59253696663",
+        "body": "\n        <div class=\"grid-row\">\n            <div class=\"col-12\">\n                <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...\u00a0\n\n                    {{interaction_textentryinteraction_583d7ef9340df566552260}} qui street art .\n\n                <\/p>\n            <\/div>\n        <\/div>\n    ",
+        "elements": {
+            "interaction_textentryinteraction_583d7ef9340df566552260": {
+                "serial": "interaction_textentryinteraction_583d7ef9340df566552260",
+                "qtiClass": "textEntryInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE",
+                    "base": 10,
+                    "expectedLength": 8,
+                    "patternMask": "PARIS",
+                    "placeholderText": ""
+                },
+                "debug": {
+                    "relatedItem": "item_583d7ef92da77287593082"
+                },
+                "choices": {}
+            }
+        },
+        "debug": {
+            "relatedItem": "item_583d7ef92da77287593082"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_583d7ef92da77287593082"
+    },
+    "namespaces": {
+        "": "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2",
+        "m": "http:\/\/www.w3.org\/1998\/Math\/MathML",
+        "xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance"
+    },
+    "schemaLocations": {
+        "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2": "http:\/\/www.imsglobal.org\/xsd\/qti\/qtiv2p2\/imsqti_v2p2p1.xsd"
+    },
+    "stylesheets": {
+        "stylesheet_583d7ef93055a662867673": {
+            "serial": "stylesheet_583d7ef93055a662867673",
+            "qtiClass": "stylesheet",
+            "attributes": {
+                "href": "style\/custom\/tao-user-styles.css",
+                "type": "text\/css",
+                "media": "all",
+                "title": ""
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            }
+        }
+    },
+    "outcomes": {
+        "outcomedeclaration_583d7ef932533850568122": {
+            "identifier": "SCORE",
+            "serial": "outcomedeclaration_583d7ef932533850568122",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "SCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            },
+            "defaultValue": null
+        }
+    },
+    "responses": {
+        "responsedeclaration_583d7ef93187a607546486": {
+            "identifier": "RESPONSE",
+            "serial": "responsedeclaration_583d7ef93187a607546486",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE",
+                "cardinality": "single",
+                "baseType": "integer"
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "http:\/\/www.imsglobal.org\/question\/qti_v2p1\/rptemplates\/match_correct",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        }
+    },
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_templatesdriven_583d7ef9372b1321065587",
+        "qtiClass": "responseProcessing",
+        "attributes": [],
+        "debug": {
+            "relatedItem": "item_583d7ef92da77287593082"
+        },
+        "processingType": "templateDriven",
+        "responseRules": [
+            {
+                "qtiClass": "responseCondition",
+                "responseIf": {
+                    "qtiClass": "responseIf",
+                    "expression": {
+                        "qtiClass": "match",
+                        "expressions": [
+                            {
+                                "qtiClass": "variable",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            },
+                            {
+                                "qtiClass": "correct",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            }
+                        ]
+                    },
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "1"
+                            }
+                        }
+                    ]
+                },
+                "responseElse": {
+                    "qtiClass": "responseElse",
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "0"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "apipAccessibility": ""
+}

--- a/test/samples/json/text-entry-inputmode-text.json
+++ b/test/samples/json/text-entry-inputmode-text.json
@@ -1,0 +1,175 @@
+{
+    "identifier": "i1480079448133120",
+    "serial": "item_583d7ef92da77287593082",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "i1480079448133120",
+        "title": "Item 12",
+        "label": "text interactions",
+        "xml:lang": "it-IT",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "3.2.0-sprint39",
+        "class": ""
+    },
+    "body": {
+        "serial": "container_containeritembody_583d7ef92da59253696663",
+        "body": "\n        <div class=\"grid-row\">\n            <div class=\"col-12\">\n                <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...\u00a0\n\n                    {{interaction_textentryinteraction_583d7ef9340df566552260}} qui street art .\n\n                <\/p>\n            <\/div>\n        <\/div>\n    ",
+        "elements": {
+            "interaction_textentryinteraction_583d7ef9340df566552260": {
+                "serial": "interaction_textentryinteraction_583d7ef9340df566552260",
+                "qtiClass": "textEntryInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE",
+                    "base": 10,
+                    "expectedLength": 8,
+                    "patternMask": "PARIS",
+                    "placeholderText": ""
+                },
+                "debug": {
+                    "relatedItem": "item_583d7ef92da77287593082"
+                },
+                "choices": {}
+            }
+        },
+        "debug": {
+            "relatedItem": "item_583d7ef92da77287593082"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_583d7ef92da77287593082"
+    },
+    "namespaces": {
+        "": "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2",
+        "m": "http:\/\/www.w3.org\/1998\/Math\/MathML",
+        "xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance"
+    },
+    "schemaLocations": {
+        "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2": "http:\/\/www.imsglobal.org\/xsd\/qti\/qtiv2p2\/imsqti_v2p2p1.xsd"
+    },
+    "stylesheets": {
+        "stylesheet_583d7ef93055a662867673": {
+            "serial": "stylesheet_583d7ef93055a662867673",
+            "qtiClass": "stylesheet",
+            "attributes": {
+                "href": "style\/custom\/tao-user-styles.css",
+                "type": "text\/css",
+                "media": "all",
+                "title": ""
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            }
+        }
+    },
+    "outcomes": {
+        "outcomedeclaration_583d7ef932533850568122": {
+            "identifier": "SCORE",
+            "serial": "outcomedeclaration_583d7ef932533850568122",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "SCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            },
+            "defaultValue": null
+        }
+    },
+    "responses": {
+        "responsedeclaration_583d7ef93187a607546486": {
+            "identifier": "RESPONSE",
+            "serial": "responsedeclaration_583d7ef93187a607546486",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE",
+                "cardinality": "single",
+                "baseType": "string"
+            },
+            "debug": {
+                "relatedItem": "item_583d7ef92da77287593082"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "http:\/\/www.imsglobal.org\/question\/qti_v2p1\/rptemplates\/match_correct",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        }
+    },
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_templatesdriven_583d7ef9372b1321065587",
+        "qtiClass": "responseProcessing",
+        "attributes": [],
+        "debug": {
+            "relatedItem": "item_583d7ef92da77287593082"
+        },
+        "processingType": "templateDriven",
+        "responseRules": [
+            {
+                "qtiClass": "responseCondition",
+                "responseIf": {
+                    "qtiClass": "responseIf",
+                    "expression": {
+                        "qtiClass": "match",
+                        "expressions": [
+                            {
+                                "qtiClass": "variable",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            },
+                            {
+                                "qtiClass": "correct",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            }
+                        ]
+                    },
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "1"
+                            }
+                        }
+                    ]
+                },
+                "responseElse": {
+                    "qtiClass": "responseElse",
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "0"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "apipAccessibility": ""
+}


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/UNO-467

**Description**

Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode change `inputmode` to support default `text` attribute