### PR TITLE
[TAO-10499] R&O Processing - Add support of per interaction response processing to item loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiItem/core/Loader.js
+++ b/src/qtiItem/core/Loader.js
@@ -229,34 +229,6 @@ var Loader = Class.extend({
                                 .some((responseKey) => !this.item.responses[responseKey].template)
                         );
 
-                    // To migrate old test items to use per interaction response processing
-                    // missing aoutcome declarations should be added
-                    if (!customResponseProcessing && perInteractionRP) {
-                        const outcomes = Object
-                            .keys(this.item.outcomes || {})
-                            .map((outcomesSerial) => this.item.outcomes[outcomesSerial]);
-
-                        _.forEach(responseIdentifiers, responseIdentifier => {
-                            if (!outcomes.find(
-                                ({ attributes: { identifier } }) => identifier === `SCORE_${responseIdentifier}`
-                            )) {
-                                const outcome = this.loadElementData(
-                                    new Qti.outcomeDeclaration(),
-                                    {
-                                        attributes: {
-                                            baseType: 'float',
-                                            cardinality: 'single',
-                                            identifier: `SCORE_${responseIdentifier}`,
-                                        },
-                                        qtiClass: 'outcomeDeclaration',
-                                    }
-                                );
-
-                                this.item.addOutcomeDeclaration(outcome);
-                            }
-                        });
-                    }
-
                     this.item.setResponseProcessing(this.buildResponseProcessing(data.responseProcessing, customResponseProcessing));
                 }
                 this.item.setNamespaces(data.namespaces);

--- a/src/qtiItem/core/Loader.js
+++ b/src/qtiItem/core/Loader.js
@@ -24,7 +24,7 @@ import Element from 'taoQtiItem/qtiItem/core/Element';
 import xmlNsHandler from 'taoQtiItem/qtiItem/helper/xmlNsHandler';
 import moduleLoader from 'core/moduleLoader';
 import responseHelper from 'taoQtiItem/qtiItem/helper/response';
-import { itemScore as itemScoreHelper } from 'taoQtiItem/qtiItem/helper/responseRules';
+import itemScoreHelper from 'taoQtiItem/qtiItem/helper/itemScore';
 
 /**
  * If a property is given as a serialized JSON object, parse it directly to a JS object
@@ -214,7 +214,7 @@ var Loader = Class.extend({
                             .keys(this.item.outcomes || {})
                             .map((outcomesSerial) => this.item.outcomes[outcomesSerial]);
 
-                        _.each(responseIdentifiers, (responseIdentifier) => {
+                        _.forEach(responseIdentifiers, responseIdentifier => {
                             if (!outcomes.find(
                                 ({ attributes: { identifier } }) => identifier === `SCORE_${responseIdentifier}`
                             )) {

--- a/src/qtiItem/core/Loader.js
+++ b/src/qtiItem/core/Loader.js
@@ -107,7 +107,7 @@ var Loader = Class.extend({
     getLoadedClasses() {
         return _.keys(this.qti);
     },
-    loadItemData(data, callback, perInteractionRP) {
+    loadItemData(data, callback) {
         this.loadRequiredClasses(data, Qti => {
             if (typeof data === 'object' && data.qtiClass === 'assessmentItem') {
                 //unload an item from it's serial (in case of a reload)
@@ -213,8 +213,7 @@ var Loader = Class.extend({
                         (
                             responseRules.length > 0
                             && !(
-                                perInteractionRP
-                                && responseRules.length === 1
+                                responseRules.length === 1
                                 && _.isEqual(
                                     responseRules[0],
                                     itemScoreHelper(

--- a/src/qtiItem/helper/itemScore.js
+++ b/src/qtiItem/helper/itemScore.js
@@ -1,0 +1,44 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+/**
+ * Returns iteraction score response rule object
+ *
+ * @param {String} responseIdentifiers interactions reponse indentifiers
+ * @returns {Obeject}
+ */
+export default (responseIdentifiers) => {
+    const outcomeExpressions = responseIdentifiers.map((outcomeIdentifier) => ({
+        qtiClass: 'variable',
+        attributes: {
+            identifier: `SCORE_${outcomeIdentifier}`,
+        },
+    }));
+
+    return {
+        qtiClass: 'setOutcomeValue',
+        attributes: {
+            identifier: 'SCORE',
+        },
+        expression: {
+            qtiClass: 'sum',
+            expressions: outcomeExpressions,
+        },
+    };
+};

--- a/src/qtiItem/helper/response.js
+++ b/src/qtiItem/helper/response.js
@@ -17,7 +17,7 @@
  *
  */
 import _ from 'lodash';
-import { responseRules as responseRulesHelper } from 'taoQtiItem/qtiItem/helper/responseRules';
+import responseRulesHelper from 'taoQtiItem/qtiItem/helper/responseRules';
 
 const _templateNames = {
     MATCH_CORRECT: 'http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct',

--- a/src/qtiItem/helper/responseRules.js
+++ b/src/qtiItem/helper/responseRules.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
-export const responseRules = {
+export default {
     MATCH_CORRECT: (responseIdentifier, outcomeIdentifier) => ({
         qtiClass: 'responseCondition',
         responseIf: {
@@ -156,24 +156,4 @@ export const responseRules = {
             ],
         },
     }),
-};
-
-export const itemScore = (responseIdentifiers) => {
-    const outcomeExpressions = responseIdentifiers.map((outcomeIdentifier) => ({
-        qtiClass: 'variable',
-        attributes: {
-            identifier: `SCORE_${outcomeIdentifier}`,
-        },
-    }));
-
-    return {
-        qtiClass: 'setOutcomeValue',
-        attributes: {
-            identifier: 'SCORE',
-        },
-        expression: {
-            qtiClass: 'sum',
-            expressions: outcomeExpressions,
-        },
-    };
 };

--- a/src/qtiItem/helper/responseRules.js
+++ b/src/qtiItem/helper/responseRules.js
@@ -157,3 +157,23 @@ export const responseRules = {
         },
     }),
 };
+
+export const itemScore = (responseIdentifiers) => {
+    const outcomeExpressions = responseIdentifiers.map((outcomeIdentifier) => ({
+        qtiClass: 'variable',
+        attributes: {
+            identifier: `SCORE_${outcomeIdentifier}`,
+        },
+    }));
+
+    return {
+        qtiClass: 'setOutcomeValue',
+        attributes: {
+            identifier: 'SCORE',
+        },
+        expression: {
+            qtiClass: 'sum',
+            expressions: outcomeExpressions,
+        },
+    };
+};

--- a/test/qtiItem/core/loader/test.js
+++ b/test/qtiItem/core/loader/test.js
@@ -1202,14 +1202,6 @@ define([
                 'loadItemData recognize response processing type'
             );
 
-            const outcomeSerial = Object.keys(item.outcomes)[0];
-
-            assert.equal(
-                item.outcomes[outcomeSerial].attributes.identifier,
-                `SCORE_testresponse`,
-                'loadItemData create missing outcomes'
-            );
-
             ready();
         }, true);
     });

--- a/test/qtiItem/core/loader/test.js
+++ b/test/qtiItem/core/loader/test.js
@@ -30,6 +30,7 @@ define([
     'taoQtiItem/qtiItem/core/interactions/GraphicGapMatchInteraction',
     'taoQtiItem/qtiItem/core/variables/ResponseDeclaration',
     'taoQtiItem/qtiItem/helper/responseRules',
+    'taoQtiItem/qtiItem/helper/itemScore',
 ], function (...args) {
     const [
         QtiItemLoader,
@@ -46,6 +47,7 @@ define([
         GraphicGapMatchInteractionQtiClass,
         ResponseDeclarationQtiClass,
         responseRulesHelper,
+        itemScoreHelper,
     ] = args;
 
     QUnit.module('QTI item loader');
@@ -986,7 +988,7 @@ define([
             responseProcessing: {
                 qtiClass: 'responseProcessing',
                 responseRules: [
-                    responseRulesHelper.responseRules.MATCH_CORRECT('testresponse', 'testoutcome'),
+                    responseRulesHelper.MATCH_CORRECT('testresponse', 'testoutcome'),
                 ],
                 serial: 'loadItemDataResponseProcessing',
             },
@@ -1091,8 +1093,8 @@ define([
             responseProcessing: {
                 qtiClass: 'responseProcessing',
                 responseRules: [
-                    responseRulesHelper.responseRules.MATCH_CORRECT('testresponse', 'testoutcome'),
-                    responseRulesHelper.responseRules.MATCH_CORRECT('testresponse1', 'testoutcome1'),
+                    responseRulesHelper.MATCH_CORRECT('testresponse', 'testoutcome'),
+                    responseRulesHelper.MATCH_CORRECT('testresponse1', 'testoutcome1'),
                 ],
                 serial: 'loadItemDataCustomResponseProcessingResponseProcessing',
             },
@@ -1129,8 +1131,8 @@ define([
             responseProcessing: {
                 qtiClass: 'responseProcessing',
                 responseRules: [
-                    responseRulesHelper.responseRules.MATCH_CORRECT('testresponse', 'testoutcome'),
-                    responseRulesHelper.itemScore(['testresponse']),
+                    responseRulesHelper.MATCH_CORRECT('testresponse', 'testoutcome'),
+                    itemScoreHelper(['testresponse']),
                 ],
                 serial: 'loadItemDataCustomResponseProcessingResponseProcessing',
             },
@@ -1181,8 +1183,8 @@ define([
             responseProcessing: {
                 qtiClass: 'responseProcessing',
                 responseRules: [
-                    responseRulesHelper.responseRules.MATCH_CORRECT('testresponse', 'testoutcome'),
-                    responseRulesHelper.itemScore(['testresponse']),
+                    responseRulesHelper.MATCH_CORRECT('testresponse', 'testoutcome'),
+                    itemScoreHelper(['testresponse']),
                 ],
                 serial: 'loadItemDataCustomResponseProcessingResponseProcessing',
             },

--- a/test/qtiItem/core/loader/test.js
+++ b/test/qtiItem/core/loader/test.js
@@ -1115,4 +1115,94 @@ define([
             ready();
         });
     });
+
+    QUnit.test('loadItemData::perInteractionRP=true', function (assert) {
+        const ready = assert.async();
+        const loader = new QtiItemLoader();
+        const data = {
+            body: {
+                body: 'testBody',
+                elements: {},
+            },
+            qtiClass: 'assessmentItem',
+            serial: 'loadItemDataCustomResponseProcessing',
+            responseProcessing: {
+                qtiClass: 'responseProcessing',
+                responseRules: [
+                    responseRulesHelper.responseRules.MATCH_CORRECT('testresponse', 'testoutcome'),
+                    responseRulesHelper.itemScore(['testresponse']),
+                ],
+                serial: 'loadItemDataCustomResponseProcessingResponseProcessing',
+            },
+            responses: {
+                loadItemDataResponse: {
+                    attributes: {
+                        identifier: 'testresponse',
+                    },
+                    identifier: 'testresponse',
+                    qtiClass: 'responseDeclaration',
+                    serial: 'loadItemDataCustomResponseProcessingResponse',
+                }
+            },
+            outcomeDeclaration: {
+                qtiClass: 'outcomeDeclaration',
+            },
+        };
+
+        loader.loadItemData(data, (item) => {
+            assert.equal(
+                item.responseProcessing.processingType,
+                'templateDriven',
+                'loadItemData recognize response processing type'
+            );
+
+            const outcomeSerial = Object.keys(item.outcomes)[0];
+
+            assert.equal(
+                item.outcomes[outcomeSerial].attributes.identifier,
+                `SCORE_testresponse`,
+                'loadItemData create missing outcomes'
+            );
+
+            ready();
+        }, true);
+    });
+
+    QUnit.test('loadItemData::perInteractionRP=false', function (assert) {
+        const ready = assert.async();
+        const loader = new QtiItemLoader();
+        const data = {
+            body: {
+                body: 'testBody',
+                elements: {},
+            },
+            qtiClass: 'assessmentItem',
+            serial: 'loadItemDataCustomResponseProcessing',
+            responseProcessing: {
+                qtiClass: 'responseProcessing',
+                responseRules: [
+                    responseRulesHelper.responseRules.MATCH_CORRECT('testresponse', 'testoutcome'),
+                    responseRulesHelper.itemScore(['testresponse']),
+                ],
+                serial: 'loadItemDataCustomResponseProcessingResponseProcessing',
+            },
+            responses: {
+                loadItemDataResponse: {
+                    identifier: 'testresponse',
+                    qtiClass: 'responseDeclaration',
+                    serial: 'loadItemDataCustomResponseProcessingResponse',
+                }
+            }
+        };
+
+        loader.loadItemData(data, (item) => {
+            assert.equal(
+                item.responseProcessing.processingType,
+                'custom',
+                'loadItemData recognize response processing type'
+            );
+
+            ready();
+        }, false);
+    });
 });

--- a/test/qtiItem/helper/responseRules/test.html
+++ b/test/qtiItem/helper/responseRules/test.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <title>XML Namespace Handler Test</title>
+        <title>Response rules helper</title>
         <script type="text/javascript" src="/environment/require.js"></script>
         <script type="text/javascript">
             require(['/environment/config.js'], function() {

--- a/test/qtiItem/helper/responseRules/test.js
+++ b/test/qtiItem/helper/responseRules/test.js
@@ -17,7 +17,8 @@
  */
 define([
     'taoQtiItem/qtiItem/helper/responseRules',
-], function (responseRulesHelper) {
+    'taoQtiItem/qtiItem/helper/itemScore',
+], function (responseRulesHelper, itemScoreHelper) {
     'use strict';
 
     const responseIdentifier = 'testResponseIdentifier';
@@ -183,7 +184,7 @@ define([
     };
 
     QUnit.test('MATCH_CORRECT', function (assert) {
-        const actual = responseRulesHelper.responseRules.MATCH_CORRECT(responseIdentifier, outcomeIdentifier);
+        const actual = responseRulesHelper.MATCH_CORRECT(responseIdentifier, outcomeIdentifier);
 
         assert.deepEqual(
             actual,
@@ -193,7 +194,7 @@ define([
     });
 
     QUnit.test('MAP_RESPONSE', function (assert) {
-        const actual = responseRulesHelper.responseRules.MAP_RESPONSE(responseIdentifier, outcomeIdentifier);
+        const actual = responseRulesHelper.MAP_RESPONSE(responseIdentifier, outcomeIdentifier);
 
         assert.deepEqual(
             actual,
@@ -203,7 +204,7 @@ define([
     });
 
     QUnit.test('MAP_RESPONSE_POINT', function (assert) {
-        const actual = responseRulesHelper.responseRules.MAP_RESPONSE_POINT(responseIdentifier, outcomeIdentifier);
+        const actual = responseRulesHelper.MAP_RESPONSE_POINT(responseIdentifier, outcomeIdentifier);
 
         assert.deepEqual(
             actual,
@@ -213,7 +214,7 @@ define([
     });
 
     QUnit.test('itemScore', function (assert) {
-        const actual = responseRulesHelper.itemScore([responseIdentifier]);
+        const actual = itemScoreHelper([responseIdentifier]);
 
         assert.deepEqual(
             actual,

--- a/test/qtiItem/helper/responseRules/test.js
+++ b/test/qtiItem/helper/responseRules/test.js
@@ -163,6 +163,23 @@ define([
                 ],
             },
         },
+        itemScore: {
+            qtiClass: 'setOutcomeValue',
+            attributes: {
+                identifier: 'SCORE',
+            },
+            expression: {
+                qtiClass: 'sum',
+                expressions: [
+                    {
+                        qtiClass: 'variable',
+                        attributes: {
+                            identifier: `SCORE_${responseIdentifier}`,
+                        },
+                    },
+                ],
+            },
+        }
     };
 
     QUnit.test('MATCH_CORRECT', function (assert) {
@@ -192,6 +209,16 @@ define([
             actual,
             responseRules.MAP_RESPONSE_POINT,
             'build MAP_RESPONSE_POINT response rule'
+        );
+    });
+
+    QUnit.test('itemScore', function (assert) {
+        const actual = responseRulesHelper.itemScore([responseIdentifier]);
+
+        assert.deepEqual(
+            actual,
+            responseRules.itemScore,
+            'build item score response rule'
         );
     });
 });


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-10497
 
Add support of per interaction response processing to qti item loader

NOTE:
Functionality available only thought additional param of qti item loader. can be tested on playground env provided in the comment for ticket 

#### How to test
 
- prepare an instance of TAO with `xmlEdit` and `xmlEditRp ` installed
- prepare an item with interactions with different response processing templates
- try to open item for authoring. make sure that response processing templates properly recognized and missing outcome declaration created
- change item response processing to custom and use per interaction response template form confluence document https://oat-sa.atlassian.net/wiki/spaces/NEX/pages/483557803/Authoring+interaction+level+item+scores
- try to open item for authoring. make sure that response processing still recognized as `templateDriven`
  
#### Dependencies
   
Requires:
 - [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/104