### PR TITLE
Fix/CGA-167/style attribute is added to the item images with the same value as the item container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/tpl/img.tpl
+++ b/src/qtiCommonRenderer/tpl/img.tpl
@@ -8,11 +8,6 @@
     {{#if attributes.height}}height="{{attributes.height}}" {{/if}}
     {{#if attributes.width}}width="{{attributes.width}}" {{/if}}
     {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
-    {{#if attributes.height}}
-        style="height: {{attributes.height}}px; width: {{attributes.width}}px;"
-        {{else}}
-        style="width: {{attributes.width}};"
-    {{/if}}
     {{#if attributes.[aria-describedby]}} aria-describedby="{{attributes.[aria-describedby]}}"{{/if}}
     {{#if attributes.[aria-hidden]}} aria-hidden="{{attributes.[aria-hidden]}}"{{/if}}
     {{#if attributes.[aria-label]}} aria-label="{{attributes.[aria-label]}}"{{/if}}


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/CGA-167
- https://github.com/oat-sa/extension-tao-itemqti/pull/1552
- https://github.com/oat-sa/extension-tao-itemqti/pull/1494
- https://github.com/oat-sa/tao-item-runner-qti-fe/pull/74
**Description:** The image container should be responsible for setting the proper image size 
**How to test:** 
- create item/shared stimulus with an image
- set a responsive mode for image
- check preview mode of item/shared stimulus