### PR TITLE
fix mime type file extension for upload file interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/helpers/uploadMime.js
+++ b/src/qtiCommonRenderer/helpers/uploadMime.js
@@ -40,8 +40,16 @@ var uploadMime = {
             { mime: 'video/mp4', label: __('MP4 video') },
             { mime: 'video/quicktime', label: __('Quicktime video') },
             { mime: 'video/x-ms-wmv', label: __('Windows Media video') },
-            { mime: 'video/x-flv', label: __('Flash video') },
-            { mime: 'text/csv', label: __('CSV file') },
+            {
+                mime: 'video/x-flv',
+                label: __('Flash video'),
+                equivalent: ['.flv']
+            },
+            {
+                mime: 'text/csv',
+                label: __('CSV file'),
+                equivalent: ['.csv']
+            },
             {
                 mime: 'application/msword',
                 label: __('Microsoft Word'),
@@ -57,10 +65,26 @@ var uploadMime = {
                 label: __('Microsoft Powerpoint'),
                 equivalent: ['application/vnd.openxmlformats-officedocument.presentationml.presentation']
             },
-            { mime: 'application/vnd.oasis.opendocument.text', label: __('OpenDocument text document') },
-            { mime: 'application/vnd.oasis.opendocument.spreadsheet', label: __('OpenDocument spreadsheet document') },
-            { mime: 'text/x-c', label: __('C++ file (.cpp)') },
-            { mime: 'text/pascal', label: __('Pascal file (.pas)') }
+            {
+                mime: 'application/vnd.oasis.opendocument.text',
+                label: __('OpenDocument text document'),
+                equivalent: ['.odf']
+            },
+            {
+                mime: 'application/vnd.oasis.opendocument.spreadsheet',
+                label: __('OpenDocument spreadsheet document'),
+                equivalent: ['.ods']
+            },
+            {
+                mime: 'text/x-c',
+                label: __('C++ file (.cpp)'),
+                equivalent: ['.cpp']
+            },
+            {
+                mime: 'text/pascal',
+                label: __('Pascal file (.pas)'),
+                equivalent: ['.pas']
+            }
         ];
     },
 


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-10387
 
added file types for some mime types
  
#### How to test

- aopen any test item for authoring
- add file upload interaction to item
- save item and open item preview
- ensure selected Pascal, C, CSV, FLS, etc mime types correctly used as file type filter
  
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1555