### PR TITLE
change textarea and ckeditor to div

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.2",
+    "version": "0.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.1",
+    "version": "0.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.1",
+    "version": "0.14.0",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.2",
+    "version": "0.14.0",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -866,9 +866,9 @@ export default {
     destroy: destroy,
     getState: getState,
     setState: setState,
-
     enable: enable,
     disable: disable,
     clearText: clearText,
-    setText: setText
+    setText: setText,
+    inputLimiter: inputLimiter
 };

--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -21,7 +21,10 @@
  * @author Ansul Sharma <ansultaotesting.com>
  */
 import template from 'taoQtiItem/reviewRenderer/tpl/interactions/extendedTextInteraction';
-import extendedTextInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction';
+import extendedTextInteraction, {
+    inputLimiter
+} from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction';
+import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 
 /**
  * * Disables the ckEditor and renders the interaction as usual
@@ -30,10 +33,234 @@ import extendedTextInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/inte
  * @returns {*}
  */
 const render = interaction => {
-    extendedTextInteraction.disable(interaction);
+    return new Promise(function (resolve, reject) {
+        var $el, expectedLength, minStrings, patternMask, placeholderType;
+        var _getNumStrings;
+        var $container = containerHelper.get(interaction);
+        var multiple = _isMultiple(interaction);
+        var placeholderText = interaction.attr('placeholderText');
 
-    return extendedTextInteraction.render(interaction);
+        if (!multiple) {
+            $el = $container.find('div.text-container');
+            if (placeholderText) {
+                $el.attr('placeholder', placeholderText);
+            }
+            $el.on('keyup.commonRenderer change.commonRenderer', function () {
+                containerHelper.triggerResponseChangeEvent(interaction, {});
+            });
 
+            resolve();
+
+            //multiple inputs
+        } else {
+            $el = $container.find('div.text-container');
+            minStrings = interaction.attr('minStrings');
+            expectedLength = interaction.attr('expectedLength');
+            patternMask = interaction.attr('patternMask');
+
+            //setting the checking for minimum number of answers
+            if (minStrings) {
+                //get the number of filled inputs
+                _getNumStrings = function ($element) {
+                    var num = 0;
+                    $element.each(function () {
+                        if ($(this).innerText !== '') {
+                            num++;
+                        }
+                    });
+
+                    return num;
+                };
+            }
+
+            //set the fields width
+            if (expectedLength) {
+                expectedLength = parseInt(expectedLength, 10);
+
+                if (expectedLength > 0) {
+                    $el.each(function () {
+                        $(this).css('width', expectedLength + 'em');
+                    });
+                }
+            }
+
+            //set the fields placeholder
+            if (placeholderText) {
+                /**
+                 * The type of the fileds placeholder:
+                 * multiple - set placeholder for each field
+                 * first - set placeholder only for first field
+                 * none - dont set placeholder
+                 */
+                placeholderType = 'first';
+
+                if (placeholderType === 'multiple') {
+                    $el.each(function () {
+                        $(this).attr('placeholder', placeholderText);
+                    });
+                } else if (placeholderType === 'first') {
+                    $el.first().attr('placeholder', placeholderText);
+                }
+            }
+            resolve();
+        }
+    });
+};
+
+/**
+ * Get the interaction format
+ * @param {Object} interaction - the extended text interaction model
+ * @returns {String} format in 'plain', 'xhtml', 'preformatted'
+ */
+function _getFormat(interaction) {
+    var format = interaction.attr('format');
+    if (_.contains(['plain', 'xhtml', 'preformatted'], format)) {
+        return format;
+    }
+    return 'plain';
+}
+
+/**
+ * return the value of the textarea or ckeditor data
+ * @param  {Object} interaction
+ * @param  {Boolean} raw Tells if the returned data does not have to be filtered (i.e. XHTML tags not removed)
+ * @return {String}             the value
+ */
+function _getTextareaValue(interaction) {
+    if (_getFormat(interaction) === 'xhtml') {
+        return containerHelper.get(interaction).find('div.text-container')[0].innerHTML;
+    } else {
+        return containerHelper.get(interaction).find('div.text-container')[0].innerText;
+    }
+}
+
+/**
+ * Whether or not multiple strings are expected from the candidate to
+ * compose a valid response.
+ *
+ * @param {Object} interaction - the extended text interaction model
+ * @returns {Boolean} true if a multiple
+ */
+function _isMultiple(interaction) {
+    var attributes = interaction.getAttributes();
+    var response = interaction.getResponseDeclaration();
+    return !!(
+        attributes.maxStrings &&
+        (response.attr('cardinality') === 'multiple' || response.attr('cardinality') === 'ordered')
+    );
+}
+
+/**
+ * Reset the textarea / ckEditor
+ * @param {Object} interaction - the extended text interaction model
+ */
+const resetResponse = interaction => {
+    containerHelper.get(interaction).find('div.text-container')[0].innerText = '';
+};
+
+const setText = (interaction, text) => {
+    var limiter = inputLimiter(interaction);
+
+    containerHelper.get(interaction).find('div.text-container')[0].innerHTML = text;
+
+    if (limiter.enabled) {
+        limiter.updateCounter();
+    }
+};
+
+/**
+ * Return the response of the rendered interaction
+ *
+ * The response format follows the IMS PCI recommendation :
+ * http://www.imsglobal.org/assessment/pciv1p0cf/imsPCIv1p0cf.html#_Toc353965343
+ *
+ * Available base types are defined in the QTI v2.1 information model:
+ * http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10296
+ *
+ * @param {Object} interaction - the extended text interaction model
+ * @returns {object}
+ */
+const getResponse = interaction => {
+    var $container = containerHelper.get(interaction);
+    var attributes = interaction.getAttributes();
+    var responseDeclaration = interaction.getResponseDeclaration();
+    var baseType = responseDeclaration.attr('baseType');
+    var numericBase = attributes.base || 10;
+    var multiple = _isMultiple(interaction);
+    var ret = multiple ? { list: {} } : { base: {} };
+    var values;
+    var value = '';
+
+    if (multiple) {
+        values = [];
+
+        $container.find('div.text-container').each(function (i) {
+            var $el = $(this);
+
+            if (attributes.placeholderText && $el.innerText === attributes.placeholderText) {
+                values[i] = '';
+            } else {
+                if (baseType === 'integer') {
+                    values[i] = parseInt($el.innerText, numericBase);
+                    values[i] = isNaN(values[i]) ? '' : values[i];
+                } else if (baseType === 'float') {
+                    values[i] = parseFloat($el.innerText);
+                    values[i] = isNaN(values[i]) ? '' : values[i];
+                } else if (baseType === 'string') {
+                    values[i] = $el.innerText;
+                }
+            }
+        });
+
+        ret.list[baseType] = values;
+    } else {
+        if (attributes.placeholderText && _getTextareaValue(interaction) === attributes.placeholderText) {
+            value = '';
+        } else {
+            if (baseType === 'integer') {
+                value = parseInt(_getTextareaValue(interaction), numericBase);
+            } else if (baseType === 'float') {
+                value = parseFloat(_getTextareaValue(interaction));
+            } else if (baseType === 'string') {
+                value = _getTextareaValue(interaction, true);
+            }
+        }
+
+        ret.base[baseType] = isNaN(value) && typeof value === 'number' ? '' : value;
+    }
+
+    return ret;
+};
+
+/**
+ * Set the response to the rendered interaction.
+ *
+ * The response format follows the IMS PCI recommendation :
+ * http://www.imsglobal.org/assessment/pciv1p0cf/imsPCIv1p0cf.html#_Toc353965343
+ *
+ * Available base types are defined in the QTI v2.1 information model:
+ * http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10296
+ *
+ * @param {Object} interaction - the extended text interaction model
+ * @param {object} response
+ */
+const setResponse = (interaction, response) => {
+    const _setMultipleVal = function (identifier, value) {
+        interaction.getContainer().find('#' + identifier)[0].innerHTML = value;
+    };
+
+    const baseType = interaction.getResponseDeclaration().attr('baseType');
+
+    if (response.base && response.base[baseType] !== undefined) {
+        setText(interaction, response.base[baseType]);
+    } else if (response.list && response.list[baseType]) {
+        for (var i in response.list[baseType]) {
+            var serial = response.list.serial === undefined ? '' : response.list.serial[i];
+            _setMultipleVal(serial + '_' + i, response.list[baseType][i]);
+        }
+    } else {
+        throw new Error('wrong response format in argument.');
+    }
 };
 
 /**
@@ -41,4 +268,11 @@ const render = interaction => {
  * @exports qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction
  */
 
-export default Object.assign({}, extendedTextInteraction, {template, render});
+export default Object.assign({}, extendedTextInteraction, {
+    template,
+    render,
+    getResponse,
+    setResponse,
+    resetResponse,
+    setText
+});

--- a/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
+++ b/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
@@ -8,25 +8,18 @@
             {{/each}}
         {{else}}
             {{#each maxStringLoop}}
-                <textarea
-                    readonly
-                    class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
-                    name="{{attributes.identifier}}_{{this}}"
-                    {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"{{/if}}
-                    aria-labelledby="{{promptId}}"
-                ></textarea>
+                <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
+                    name="{{attributes.identifier}}_{{this}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"
+                    {{/if}} aria-labelledby="{{promptId}}"></div>
             {{/each}}
         {{/equal}}
     {{else}}
         {{#equal attributes.format xhtml}}
         <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" contenteditable></div>
         {{else}}
-            <textarea
-                readonly
-                class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
-                {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"{{/if}}
-                aria-labelledby="{{promptId}}"
-            ></textarea>
+            <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
+                    name="{{attributes.identifier}}_{{this}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"
+                    {{/if}} aria-labelledby="{{promptId}}"></div>
         {{/equal}}
     {{/if}}
     <div class="text-counter">

--- a/test/reviewRenderer/interactions/extendedText/test.html
+++ b/test/reviewRenderer/interactions/extendedText/test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Extended Text Interaction Test</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function () {
+                require(['qunitEnv'], function () {
+                    require(['taoQtiItem/test/reviewRenderer/interactions/extendedText/test'], function () {
+                        QUnit.start();
+                        QUnit.config.reorder = false;
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="item-container-0"></div>
+            <div id="item-container-1"></div>
+            <div id="item-container-2"></div>
+            <div id="item-container-3"></div>
+            <div id="item-container-4"></div>
+            <div id="item-container-5"></div>
+            <div id="item-container-6"></div>
+            <div id="item-container-7"></div>
+            <div id="item-container-8"></div>
+            <div id="item-container-9"></div>
+        </div>
+
+        <div id="outside-container"></div>
+    </body>
+</html>

--- a/test/reviewRenderer/interactions/extendedText/test.js
+++ b/test/reviewRenderer/interactions/extendedText/test.js
@@ -1,0 +1,474 @@
+define([
+    'jquery',
+    'lodash',
+    'taoQtiItem/runner/qtiItemRunner',
+    'json!taoQtiItem/test/samples/json/postcard.json',
+    'json!taoQtiItem/test/samples/json/formated-card.json'
+], function ($, _, qtiItemRunner, itemDataPlain, itemDataXhtml) {
+    'use strict';
+
+    var runner;
+    var fixtureContainerId = 'item-container-';
+
+    /** PLAIN **/
+
+    QUnit.module('Extended Text Interaction - plain format', {
+        afterEach: function () {
+            if (runner) {
+                runner.clear();
+            }
+        }
+    });
+
+    QUnit.test('renders correctly', function (assert) {
+        var ready = assert.async();
+        assert.expect(10);
+
+        var $container = $('#' + fixtureContainerId + '0');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataPlain, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                //Check DOM
+                assert.equal($container.children().length, 1, 'the container a elements');
+                assert.equal(
+                    $container.children('.qti-item').length,
+                    1,
+                    'the container contains a the root element .qti-item'
+                );
+                assert.equal(
+                    $container.find('.qti-itemBody').length,
+                    1,
+                    'the container contains a the body element .qti-itemBody'
+                );
+                assert.equal(
+                    $container.find('.qti-interaction').length,
+                    1,
+                    'the container contains an interaction .qti-interaction'
+                );
+                assert.equal(
+                    $container.find('.qti-interaction.qti-extendedTextInteraction').length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+                assert.equal(
+                    $container.find('.qti-extendedTextInteraction .qti-prompt-container').length,
+                    1,
+                    'the interaction contains a prompt'
+                );
+                assert.equal(
+                    $container.find('.qti-extendedTextInteraction .instruction-container').length,
+                    1,
+                    'the interaction contains a instruction box'
+                );
+
+                //Check DOM data
+                assert.equal(
+                    $container.children('.qti-item').data('identifier'),
+                    'extendedText',
+                    'the .qti-item node has the right identifier'
+                );
+
+                ready();
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.test('enables to load a response', function (assert) {
+        var ready = assert.async();
+        assert.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '2');
+        var response = { base: { string: 'test' } };
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataPlain, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                assert.equal(
+                    $container.find('.qti-interaction.qti-extendedTextInteraction').length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+
+                var interaction = this._item.getInteractions()[0];
+                interaction.renderer.setResponse(interaction, response);
+
+                assert.deepEqual(
+                    this.getState(),
+                    { RESPONSE: { response: response } },
+                    'the response state is equal to the loaded response'
+                );
+
+                assert.equal(
+                    $container.find('div.text-container')[0].innerHTML,
+                    response.base.string,
+                    'the textarea displays the loaded response'
+                );
+
+                ready();
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.test('destroys', function (assert) {
+        var ready = assert.async();
+        assert.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '3');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataPlain, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                var self = this;
+
+                //Call destroy manually
+                var interaction = this._item.getInteractions()[0];
+                interaction.renderer.destroy(interaction);
+
+                assert.equal(
+                    $container.find('.qti-interaction.qti-extendedTextInteraction').length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+
+                $container.find('div.text-container')[0].innerText = 'test';
+
+                _.delay(function () {
+                    assert.deepEqual(
+                        self.getState(),
+                        { RESPONSE: { response: { base: { string: 'test' } } } },
+                        'The response state is still related to text content'
+                    );
+                    assert.equal(
+                        $container.find('.qti-extendedTextInteraction .instruction-container').children().length,
+                        0,
+                        'there is no instructions anymore'
+                    );
+
+                    ready();
+                }, 100);
+            })
+            .on('statechange', function () {
+                assert.ok(false, 'Text input does not trigger response once destroyed');
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.test('resets the response', function (assert) {
+        var ready = assert.async();
+        assert.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '4');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataPlain, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                var self = this;
+
+                assert.equal(
+                    $container.find('.qti-interaction.qti-extendedTextInteraction').length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+
+                $container.find('div.text-container')[0].innerText = 'test';
+
+                _.delay(function () {
+                    assert.deepEqual(
+                        self.getState(),
+                        { RESPONSE: { response: { base: { string: 'test' } } } },
+                        'A response is set'
+                    );
+
+                    //Call destroy manually
+                    var interaction = self._item.getInteractions()[0];
+                    interaction.renderer.resetResponse(interaction);
+
+                    _.delay(function () {
+                        assert.deepEqual(
+                            self.getState(),
+                            { RESPONSE: { response: { base: { string: '' } } } },
+                            'The response is cleared'
+                        );
+
+                        ready();
+                    }, 100);
+                }, 100);
+            })
+            .init()
+            .render($container);
+    });
+
+    // /** XHTML **/
+
+    QUnit.module('Extended Text Interaction - XHTML format', {
+        afterEach: function (assert) {
+            if (runner) {
+                runner.clear();
+            }
+        }
+    });
+
+    QUnit.test('renders correctly', function (assert) {
+        var ready = assert.async();
+        assert.expect(10);
+
+        var $container = $('#' + fixtureContainerId + '5');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataXhtml, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                //Check DOM
+                assert.equal($container.children().length, 1, 'the container a elements');
+                assert.equal(
+                    $container.children('.qti-item').length,
+                    1,
+                    'the container contains a the root element .qti-item'
+                );
+                assert.equal(
+                    $container.find('.qti-itemBody').length,
+                    1,
+                    'the container contains a the body element .qti-itemBody'
+                );
+                assert.equal(
+                    $container.find('.qti-interaction').length,
+                    1,
+                    'the container contains an interaction .qti-interaction'
+                );
+                assert.equal(
+                    $container.find('.qti-interaction.qti-extendedTextInteraction').length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+                assert.equal(
+                    $container.find('.qti-extendedTextInteraction .qti-prompt-container').length,
+                    1,
+                    'the interaction contains a prompt'
+                );
+                assert.equal(
+                    $container.find('.qti-extendedTextInteraction .instruction-container').length,
+                    1,
+                    'the interaction contains a instruction box'
+                );
+
+                //Check DOM data
+                assert.equal(
+                    $container.children('.qti-item').data('identifier'),
+                    'extendedText',
+                    'the .qti-item node has the right identifier'
+                );
+
+                _.delay(ready, 10);
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.test('enables to load a response', function (assert) {
+        var ready = assert.async();
+        assert.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '7');
+
+        //Var $container = $('#outside-container');
+        var response = { base: { string: '<strong>test</strong>' } };
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataXhtml, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                var self = this;
+
+                //Set the state
+                runner.setState({ RESPONSE: { response: response } });
+
+                assert.equal(
+                    $container.find('.qti-extendedTextInteraction').length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+                assert.deepEqual(
+                    self.getState(),
+                    { RESPONSE: { response: response } },
+                    'the response state is equal to the loaded response'
+                );
+
+                //Ck set the text with a little delay
+                _.delay(function () {
+                    assert.equal(
+                        $container.find('div.text-container')[0].innerHTML,
+                        response.base.string,
+                        'the state text is inserted'
+                    );
+
+                    _.delay(function () {
+                        ready();
+                    }, 10);
+                }, 10);
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.test('resets the response', function (assert) {
+        var ready = assert.async();
+        assert.expect(6);
+
+        var $container = $('#' + fixtureContainerId + '9');
+        var response = 'test';
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataXhtml, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                var self = this;
+
+                var interaction = self._item.getInteractions()[0];
+                var $interaction = $('.qti-extendedTextInteraction', $container);
+                assert.equal(
+                    $interaction.length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+
+                $container.find('div.text-container')[0].innerHTML = response;
+
+                assert.deepEqual(
+                    self.getState(),
+                    { RESPONSE: { response: { base: { string: response } } } },
+                    'A response is set'
+                );
+
+                _.delay(function () {
+                    interaction.renderer.resetResponse(interaction);
+
+                    assert.deepEqual(
+                        self.getState(),
+                        { RESPONSE: { response: { base: { string: '' } } } },
+                        'The response is cleared'
+                    );
+                    assert.equal($container.find('div.text-container')[0].innerHTML, '', 'the editor is cleared');
+
+                    _.delay(ready, 10);
+                }, 10);
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.test('destroys', function (assert) {
+        var ready = assert.async();
+        assert.expect(5);
+
+        var $container = $('#' + fixtureContainerId + '8');
+
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
+
+        runner = qtiItemRunner('qti', itemDataXhtml, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                var self = this;
+
+                //Call destroy manually
+                var interaction = self._item.getInteractions()[0];
+                var $interaction = $('.qti-extendedTextInteraction', $container);
+                assert.equal(
+                    $interaction.length,
+                    1,
+                    'the container contains a text interaction .qti-extendedTextInteraction'
+                );
+
+                _.delay(function () {
+                    interaction.renderer.destroy(interaction);
+
+                    _.delay(function () {
+                        assert.deepEqual(
+                            self.getState(),
+                            { RESPONSE: { response: { base: { string: '' } } } },
+                            'The response state is cleared'
+                        );
+                        assert.equal(
+                            $container.find('.qti-extendedTextInteraction .instruction-container').children().length,
+                            0,
+                            'there is no instructions anymore'
+                        );
+
+                        _.delay(ready, 10);
+                    }, 10);
+                }, 10);
+            })
+            .init()
+            .render($container);
+    });
+
+    QUnit.module('Visual Test');
+
+    QUnit.test('Display and play', function (assert) {
+        var ready = assert.async();
+        assert.expect(1);
+
+        var $container = $('#outside-container');
+        var response = { base: { string: '<strong>test</strong>' } };
+
+        assert.equal($container.length, 1, 'the item container exists');
+
+        runner = qtiItemRunner('qti', itemDataXhtml, { view: 'scorer' })
+            .on('error', function (e) {
+                assert.ok(false, e);
+                ready();
+            })
+            .on('render', function () {
+                runner.setState({ RESPONSE: { response: response } });
+                ready();
+            })
+            .init()
+            .render($container);
+    });
+});

--- a/test/runner/interactions/choice/test.js
+++ b/test/runner/interactions/choice/test.js
@@ -3,26 +3,26 @@ define([
     'lodash',
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/space-shuttle.json'
-], function($, _, qtiItemRunner, itemData) {
+], function ($, _, qtiItemRunner, itemData) {
     'use strict';
 
     var runner;
     var containerId = 'item-container';
 
     QUnit.module('Init', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             if (runner) {
                 runner.clear();
             }
         }
     });
 
-    QUnit.test('Item data loading', function(assert) {
+    QUnit.test('Item data loading', function (assert) {
         var ready = assert.async();
         assert.expect(2);
 
         runner = qtiItemRunner('qti', itemData)
-            .on('init', function() {
+            .on('init', function () {
                 assert.ok(typeof this._item === 'object', 'The item data is loaded and mapped to an object');
                 assert.ok(typeof this._item.bdy === 'object', 'The item contains a body object');
 
@@ -32,14 +32,14 @@ define([
     });
 
     QUnit.module('Render', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             if (runner) {
                 runner.clear();
             }
         }
     });
 
-    QUnit.test('Item rendering', function(assert) {
+    QUnit.test('Item rendering', function (assert) {
         var ready = assert.async();
         assert.expect(3);
 
@@ -49,7 +49,7 @@ define([
         assert.equal(container.children.length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 ready();
@@ -60,7 +60,7 @@ define([
 
     QUnit.module('Clear');
 
-    QUnit.test('Clear Item', function(assert) {
+    QUnit.test('Clear Item', function (assert) {
         var ready = assert.async();
         assert.expect(4);
 
@@ -70,12 +70,12 @@ define([
         assert.equal(container.children.length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 this.clear();
             })
-            .on('clear', function() {
+            .on('clear', function () {
                 assert.equal(container.children.length, 0, 'the container children are removed');
 
                 ready();
@@ -85,14 +85,14 @@ define([
     });
 
     QUnit.module('State', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             if (runner) {
                 runner.clear();
             }
         }
     });
 
-    QUnit.test('get state after changes', function(assert) {
+    QUnit.test('get state after changes', function (assert) {
         var ready = assert.async();
         assert.expect(12);
 
@@ -101,10 +101,10 @@ define([
         assert.ok(container instanceof HTMLElement, 'the item container exists');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('error', function(e) {
+            .on('error', function (e) {
                 console.error(e);
             })
-            .on('render', function() {
+            .on('render', function () {
                 //Default state
                 var state = this.getState();
 
@@ -114,8 +114,6 @@ define([
 
                 //Change something
                 $('[data-identifier="Discovery"]', $(container)).click();
-
-                //Debugger;
 
                 state = this.getState();
 
@@ -140,7 +138,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('set state', function(assert) {
+    QUnit.test('set state', function (assert) {
         var ready = assert.async();
         assert.expect(3);
 
@@ -149,7 +147,7 @@ define([
         assert.ok(container instanceof HTMLElement, 'the item container exists');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.ok(
                     !$('[data-identifier="Atlantis"] input', $(container)).prop('checked'),
                     'The choice is not checked'
@@ -168,7 +166,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('set multiple  states', function(assert) {
+    QUnit.test('set multiple  states', function (assert) {
         var ready = assert.async();
         assert.expect(8);
 
@@ -177,7 +175,7 @@ define([
         assert.ok(container instanceof HTMLElement, 'the item container exists');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.ok(
                     !$('[data-identifier="Atlantis"] input', $(container)).prop('checked'),
                     'The choice is not checked'
@@ -223,7 +221,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('listen state changes', function(assert) {
+    QUnit.test('listen state changes', function (assert) {
         var ready = assert.async();
         assert.expect(10);
 
@@ -232,7 +230,7 @@ define([
         assert.ok(container instanceof HTMLElement, 'the item container exists');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('statechange', function(state) {
+            .on('statechange', function (state) {
                 assert.ok(
                     $('[data-identifier="Atlantis"] input', $(container)).prop('checked'),
                     'The choice is checked'
@@ -245,7 +243,7 @@ define([
 
                 ready();
             })
-            .on('render', function() {
+            .on('render', function () {
                 var state = this.getState();
 
                 assert.ok(typeof state === 'object', 'the state is an object');
@@ -264,14 +262,14 @@ define([
     });
 
     QUnit.module('Get responses', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             if (runner) {
                 runner.clear();
             }
         }
     });
 
-    QUnit.test('no responses set', function(assert) {
+    QUnit.test('no responses set', function (assert) {
         var ready = assert.async();
         assert.expect(4);
 
@@ -280,7 +278,7 @@ define([
         assert.ok(container instanceof HTMLElement, 'the item container exists');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 var responses = this.getResponses();
 
                 assert.ok(typeof responses === 'object', 'the response is an object');
@@ -296,7 +294,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('get responses after changes', function(assert) {
+    QUnit.test('get responses after changes', function (assert) {
         var ready = assert.async();
         assert.expect(7);
 
@@ -305,7 +303,7 @@ define([
         assert.ok(container instanceof HTMLElement, 'the item container exists');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 var responses = this.getResponses();
 
                 assert.ok(typeof responses === 'object', 'the response is an object');

--- a/test/runner/provider/test.js
+++ b/test/runner/provider/test.js
@@ -27,7 +27,7 @@ define([
     'taoQtiItem/runner/provider/qti',
     'taoQtiItem/portableElementRegistry/icRegistry',
     'json!taoQtiItem/test/samples/json/space-shuttle.json'
-], function($, _, itemRunner, qtiRuntimeProvider, icRegistry, itemData) {
+], function ($, _, itemRunner, qtiRuntimeProvider, icRegistry, itemData) {
     'use strict';
 
     var runner;
@@ -35,7 +35,7 @@ define([
 
     QUnit.module('Provider API');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', function (assert) {
         assert.ok(typeof qtiRuntimeProvider !== 'undefined', 'The module exports something');
         assert.ok(typeof qtiRuntimeProvider === 'object', 'The module exports an object');
         assert.ok(
@@ -45,12 +45,12 @@ define([
     });
 
     QUnit.module('Register the provider', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             itemRunner.providers = null;
         }
     });
 
-    QUnit.test('register the qti provider', function(assert) {
+    QUnit.test('register the qti provider', function (assert) {
         assert.expect(4);
 
         assert.ok(typeof itemRunner.providers === 'undefined', 'the runner has no providers');
@@ -63,19 +63,19 @@ define([
     });
 
     QUnit.module('Provider init', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             itemRunner.providers = null;
         }
     });
 
-    QUnit.test('Item data loading', function(assert) {
+    QUnit.test('Item data loading', function (assert) {
         var ready = assert.async();
         assert.expect(2);
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
         itemRunner('qti', itemData)
-            .on('init', function() {
+            .on('init', function () {
                 assert.ok(typeof this._item === 'object', 'The item data is loaded and mapped to an object');
                 assert.ok(typeof this._item.bdy === 'object', 'The item contains a body object');
 
@@ -84,14 +84,14 @@ define([
             .init();
     });
 
-    QUnit.test('Loading wrong data', function(assert) {
+    QUnit.test('Loading wrong data', function (assert) {
         var ready = assert.async();
         assert.expect(2);
 
         itemRunner.register('qti', qtiRuntimeProvider);
 
         itemRunner('qti', { foo: true })
-            .on('error', function(message) {
+            .on('error', function (message) {
                 assert.ok(true, 'The provider triggers an error event');
                 assert.ok(typeof message === 'string', 'The error is a string');
 
@@ -101,14 +101,14 @@ define([
     });
 
     QUnit.module('Provider render', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             //Reset the provides
             runner.clear();
             itemRunner.providers = null;
         }
     });
 
-    QUnit.test('Item rendering', function(assert) {
+    QUnit.test('Item rendering', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -120,7 +120,7 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 ready();
@@ -129,7 +129,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('Issue in rendering', function(assert) {
+    QUnit.test('Issue in rendering', function (assert) {
         var ready = assert.async();
         var count = 0;
         var container = document.getElementById(containerId);
@@ -139,11 +139,11 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('init', function() {
+            .on('init', function () {
                 this._item.renderer = null;
                 this.render(container);
             })
-            .on('error', function(message) {
+            .on('error', function (message) {
                 assert.ok(true, 'The provider triggers an error event');
                 assert.ok(typeof message === 'string', 'The error is a string');
                 if (count > 0) {
@@ -155,12 +155,12 @@ define([
     });
 
     QUnit.module('Provider clear', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             itemRunner.providers = null;
         }
     });
 
-    QUnit.test('Clear a rendered item', function(assert) {
+    QUnit.test('Clear a rendered item', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -172,13 +172,13 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.equal(typeof this._item, 'object', 'the item instance is attached to the runner');
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 this.clear();
             })
-            .on('clear', function() {
+            .on('clear', function () {
                 assert.equal(container.children.length, 0, 'the container children are removed');
                 assert.equal(this._item, null, 'the item instance is also cleared');
 
@@ -188,7 +188,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('Clear a rendered item asynchronosuly', function(assert) {
+    QUnit.test('Clear a rendered item asynchronosuly', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -200,16 +200,16 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.equal(typeof this._item, 'object', 'the item instance is attached to the runner');
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 // Mock the getInteractions() method to return interaction with async clear step
-                this._item.getInteractions = function() {
+                this._item.getInteractions = function () {
                     return [
                         {
-                            clear: function() {
-                                return new Promise(function(resolve) {
+                            clear: function () {
+                                return new Promise(function (resolve) {
                                     setTimeout(resolve, 10);
                                 });
                             }
@@ -219,7 +219,7 @@ define([
 
                 this.clear();
             })
-            .on('clear', function() {
+            .on('clear', function () {
                 assert.equal(container.children.length, 0, 'the container children are removed');
                 assert.equal(this._item, null, 'the item instance is also cleared');
 
@@ -230,14 +230,14 @@ define([
     });
 
     QUnit.module('Provider state', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             //Reset the provides
             runner.clear();
             itemRunner.providers = null;
         }
     });
 
-    QUnit.test('default state structure', function(assert) {
+    QUnit.test('default state structure', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -248,7 +248,7 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 var state = this.getState();
 
                 assert.ok(typeof state === 'object', 'the state is an object');
@@ -261,7 +261,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('get state after changes', function(assert) {
+    QUnit.test('get state after changes', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -272,10 +272,10 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('error', function(e) {
+            .on('error', function (e) {
                 assert.ok(false, 'Unexpected error : ' + e.message);
             })
-            .on('render', function() {
+            .on('render', function () {
                 //Default state
                 var state = this.getState();
 
@@ -285,8 +285,6 @@ define([
 
                 //Change something
                 $('[data-identifier="Discovery"]', $(container)).click();
-
-                //Debugger;
 
                 state = this.getState();
 
@@ -311,7 +309,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('set state', function(assert) {
+    QUnit.test('set state', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -322,7 +320,7 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.ok(
                     !$('[data-identifier="Atlantis"] input', $(container)).prop('checked'),
                     'The choice is not checked'
@@ -341,7 +339,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('set multiple  states', function(assert) {
+    QUnit.test('set multiple  states', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -352,7 +350,7 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 assert.ok(
                     !$('[data-identifier="Atlantis"] input', $(container)).prop('checked'),
                     'The choice is not checked'
@@ -398,7 +396,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('listen state changes', function(assert) {
+    QUnit.test('listen state changes', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -409,7 +407,7 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('statechange', function(state) {
+            .on('statechange', function (state) {
                 assert.ok(
                     $('[data-identifier="Atlantis"] input', $(container)).prop('checked'),
                     'The choice is checked'
@@ -422,7 +420,7 @@ define([
 
                 ready();
             })
-            .on('render', function() {
+            .on('render', function () {
                 var state = this.getState();
 
                 assert.ok(typeof state === 'object', 'the state is an object');
@@ -441,13 +439,13 @@ define([
     });
 
     QUnit.module('Provider responses', {
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             runner.clear();
             itemRunner.providers = null;
         }
     });
 
-    QUnit.test('no responses set', function(assert) {
+    QUnit.test('no responses set', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -458,7 +456,7 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 var responses = this.getResponses();
 
                 assert.ok(typeof responses === 'object', 'the response is an object');
@@ -474,7 +472,7 @@ define([
             .render(container);
     });
 
-    QUnit.test('get responses after changes', function(assert) {
+    QUnit.test('get responses after changes', function (assert) {
         var ready = assert.async();
         var container = document.getElementById(containerId);
 
@@ -485,7 +483,7 @@ define([
         itemRunner.register('qti', qtiRuntimeProvider);
 
         runner = itemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', function () {
                 var responses = this.getResponses();
 
                 assert.ok(typeof responses === 'object', 'the response is an object');
@@ -514,10 +512,10 @@ define([
     });
 
     QUnit.module('Provider PIC', {
-        beforeEach: function(assert) {
+        beforeEach: function (assert) {
             icRegistry.resetProviders();
         },
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             runner.clear();
             itemRunner.providers = null;
             icRegistry.resetProviders();


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-446

**What has changed?**

At the moment, the `reviewRenderer` is rendering the extended text interaction using a `textarea` and `ckEditor` plugin. This is not good when the scorer would like to highlight the response of a test taker (which is rendered inside the `textarea` component or an `iframe` component) because you can not get the `range` of the text which is not part of the dom. To achieve the highlight feature for scorers in the reviewRenderer I have changed the textarea and ckEditor iframe with a simple div and the response is injected in this div (plain text for simple extended interactions and rich html for xhtml extended text interaction)

**How to test?**

- Check out the branch
- install this version of node modules in taoQtiItems Extention in your tao instance (https://medium.com/@jonchurch/use-github-branch-as-dependency-in-package-json-5eb609c81f1a)
- Create a test with extended text interaction in all three flavors (plain, preformatted, and XHTML)
- take the test on tao and login as a scorer on MS to review the responses of your test
-  All the extended text interactions should be working as expected and should have been rendered in a div instead of textarea and iframe
- Also run the tests: `npm run test`