### PR TITLE
Fix/TR-10/Accept a null response in the Extended Text interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -237,26 +237,23 @@ var resetResponse = function (interaction) {
  * @param {Object} interaction - the extended text interaction model
  * @param {object} response
  */
-var setResponse = function (interaction, response) {
-    var _setMultipleVal = function (identifier, value) {
-        interaction
-            .getContainer()
-            .find('#' + identifier)
-            .val(value);
+const setResponse = (interaction, response) => {
+    const _setMultipleVal = (identifier, value) => {
+        interaction.getContainer().find(`#${identifier}`).val(value);
     };
 
-    var baseType = interaction.getResponseDeclaration().attr('baseType');
+    const baseType = interaction.getResponseDeclaration().attr('baseType');
 
     if (response.base === null && Object.keys(response).length === 1) {
         response = { base: { string: '' } };
     }
 
-    if (response.base && response.base[baseType] !== undefined) {
+    if (response.base && typeof response.base[baseType] !== 'undefined') {
         setText(interaction, response.base[baseType]);
     } else if (response.list && response.list[baseType]) {
-        for (var i in response.list[baseType]) {
-            var serial = response.list.serial === undefined ? '' : response.list.serial[i];
-            _setMultipleVal(serial + '_' + i, response.list[baseType][i]);
+        for (let i in response.list[baseType]) {
+            const serial = typeof response.list.serial === 'undefined' ? '' : response.list.serial[i];
+            _setMultipleVal(`${serial}_${i}`, response.list[baseType][i]);
         }
     } else {
         throw new Error('wrong response format in argument.');

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -247,6 +247,10 @@ var setResponse = function (interaction, response) {
 
     var baseType = interaction.getResponseDeclaration().attr('baseType');
 
+    if (response.base === null && Object.keys(response).length === 1) {
+        response = { base: { string: '' } };
+    }
+
     if (response.base && response.base[baseType] !== undefined) {
         setText(interaction, response.base[baseType]);
     } else if (response.list && response.list[baseType]) {

--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -313,6 +313,10 @@ const setResponse = (interaction, response) => {
 
     const baseType = interaction.getResponseDeclaration().attr('baseType');
 
+    if (response.base === null && Object.keys(response).length === 1) {
+        response = { base: { string: '' } };
+    }
+
     if (response.base && response.base[baseType] !== undefined) {
         setText(interaction, response.base[baseType]);
     } else if (response.list && response.list[baseType]) {

--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -308,7 +308,7 @@ const getResponse = interaction => {
  */
 const setResponse = (interaction, response) => {
     const _setMultipleVal = (identifier, value) => {
-        interaction.getContainer().find('#' + identifier)[0].innerHTML = value;
+        interaction.getContainer().find(`#${identifier}`)[0].innerHTML = value;
     };
 
     const baseType = interaction.getResponseDeclaration().attr('baseType');
@@ -317,12 +317,12 @@ const setResponse = (interaction, response) => {
         response = { base: { string: '' } };
     }
 
-    if (response.base && response.base[baseType] !== undefined) {
+    if (response.base && typeof response.base[baseType] !== 'undefined') {
         setText(interaction, response.base[baseType]);
     } else if (response.list && response.list[baseType]) {
         for (let i in response.list[baseType]) {
-            const serial = response.list.serial === undefined ? '' : response.list.serial[i];
-            _setMultipleVal(serial + '_' + i, response.list[baseType][i]);
+            const serial = typeof response.list.serial === 'undefined' ? '' : response.list.serial[i];
+            _setMultipleVal(`${serial}_${i}`, response.list[baseType][i]);
         }
     } else {
         throw new Error('wrong response format in argument.');

--- a/test/qtiCommonRenderer/interactions/extendedText/test.js
+++ b/test/qtiCommonRenderer/interactions/extendedText/test.js
@@ -126,40 +126,53 @@ define([
             .render($container);
     });
 
-    QUnit.test('enables to load a response', function(assert) {
-        var ready = assert.async();
+    QUnit.cases.init([{
+        title: 'filled response',
+        response: { base: { string: 'test' } },
+        expected: { base: { string: 'test' } },
+        value: 'test'
+    }, {
+        title: 'empty response',
+        response: { base: { string: '' } },
+        expected: { base: { string: '' } },
+        value: ''
+    }, {
+        title: 'null response',
+        response: { base: null },
+        expected: { base: { string: '' } },
+        value: ''
+    }]).test('enables to load a response', (data, assert) => {
+        const ready = assert.async();
+        const $container = $(`#${fixtureContainerId}2`);
+        const buildState = response => ({ RESPONSE: { response } });
         assert.expect(5);
-
-        var $container = $('#' + fixtureContainerId + '2');
-        var response = { base: { string: 'test' } };
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', itemDataPlain)
-            .on('error', function(e) {
+            .on('error', e => {
                 assert.ok(false, e);
                 ready();
             })
-            .on('render', function() {
+            .on('render', () => {
+                runner.setState(buildState(data.response));
+
                 assert.equal(
                     $container.find('.qti-interaction.qti-extendedTextInteraction').length,
                     1,
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                var interaction = this._item.getInteractions()[0];
-                interaction.renderer.setResponse(interaction, response);
-
                 assert.deepEqual(
-                    this.getState(),
-                    { RESPONSE: { response: response } },
+                    runner.getState(),
+                    buildState(data.expected),
                     'the response state is equal to the loaded response'
                 );
 
                 assert.equal(
                     $container.find('textarea').val(),
-                    response.base.string,
+                    data.value,
                     'the textarea displays the loaded response'
                 );
 
@@ -388,54 +401,63 @@ define([
             .render($container);
     });
 
-    QUnit.test('enables to load a response', function(assert) {
-        var ready = assert.async();
+    QUnit.cases.init([{
+        title: 'filled response',
+        response: { base: { string: '<strong>test</strong>' } },
+        expected: { base: { string: '<strong>test</strong>' } },
+        value: 'test'
+    }, {
+        title: 'empty response',
+        response: { base: { string: '' } },
+        expected: { base: { string: '' } },
+        value: ''
+    }, {
+        title: 'null response',
+        response: { base: null },
+        expected: { base: { string: '' } },
+        value: ''
+    }]).test('enables to load a response', (data, assert) => {
+        const ready = assert.async();
+        const $container = $(`#${fixtureContainerId}7`);
+        const buildState = response => ({ RESPONSE: { response } });
         assert.expect(5);
-
-        var $container = $('#' + fixtureContainerId + '7');
-
-        //Var $container = $('#outside-container');
-        var response = { base: { string: '<strong>test</strong>' } };
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', itemDataXhtml)
-            .on('error', function(e) {
+            .on('error', e => {
                 assert.ok(false, e);
                 ready();
             })
-            .on('render', function() {
-                var self = this;
-
+            .on('render', () => {
                 //Set the state
-                runner.setState({ RESPONSE: { response: response } });
+                runner.setState(buildState(data.response));
 
                 assert.equal(
                     $container.find('.qti-extendedTextInteraction').length,
                     1,
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
+
                 assert.deepEqual(
-                    self.getState(),
-                    { RESPONSE: { response: response } },
+                    runner.getState(),
+                    buildState(data.expected),
                     'the response state is equal to the loaded response'
                 );
 
                 //Ck set the text with a little delay
-                _.delay(function() {
+                _.delay(() => {
                     assert.equal(
                         $('.qti-extendedTextInteraction iframe.cke_wysiwyg_frame', $container)
                             .contents()
                             .find('body')
                             .text(),
-                        'test',
+                        data.value,
                         'the state text is inserted'
                     );
 
-                    _.delay(function() {
-                        ready();
-                    }, 10);
+                    _.delay(ready, 10);
                 }, 10);
             })
             .init()

--- a/test/reviewRenderer/interactions/extendedText/test.js
+++ b/test/reviewRenderer/interactions/extendedText/test.js
@@ -81,40 +81,53 @@ define([
             .render($container);
     });
 
-    QUnit.test('enables to load a response', function (assert) {
-        var ready = assert.async();
+    QUnit.cases.init([{
+        title: 'filled response',
+        response: { base: { string: 'test' } },
+        expected: { base: { string: 'test' } },
+        value: 'test'
+    }, {
+        title: 'empty response',
+        response: { base: { string: '' } },
+        expected: { base: { string: '' } },
+        value: ''
+    }, {
+        title: 'null response',
+        response: { base: null },
+        expected: { base: { string: '' } },
+        value: ''
+    }]).test('enables to load a response', (data, assert) => {
+        const ready = assert.async();
+        const $container = $(`#${fixtureContainerId}2`);
+        const buildState = response => ({ RESPONSE: { response } });
         assert.expect(5);
-
-        var $container = $('#' + fixtureContainerId + '2');
-        var response = { base: { string: 'test' } };
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', itemDataPlain, { view: 'scorer' })
-            .on('error', function (e) {
+            .on('error', e => {
                 assert.ok(false, e);
                 ready();
             })
-            .on('render', function () {
+            .on('render', () => {
+                runner.setState(buildState(data.response));
+
                 assert.equal(
                     $container.find('.qti-interaction.qti-extendedTextInteraction').length,
                     1,
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                var interaction = this._item.getInteractions()[0];
-                interaction.renderer.setResponse(interaction, response);
-
                 assert.deepEqual(
-                    this.getState(),
-                    { RESPONSE: { response: response } },
+                    runner.getState(),
+                    buildState(data.expected),
                     'the response state is equal to the loaded response'
                 );
 
                 assert.equal(
                     $container.find('div.text-container')[0].innerHTML,
-                    response.base.string,
+                    data.value,
                     'the textarea displays the loaded response'
                 );
 
@@ -297,28 +310,38 @@ define([
             .render($container);
     });
 
-    QUnit.test('enables to load a response', function (assert) {
-        var ready = assert.async();
+    QUnit.cases.init([{
+        title: 'filled response',
+        response: { base: { string: '<strong>test</strong>' } },
+        expected: { base: { string: '<strong>test</strong>' } },
+        value: '<strong>test</strong>'
+    }, {
+        title: 'empty response',
+        response: { base: { string: '' } },
+        expected: { base: { string: '' } },
+        value: ''
+    }, {
+        title: 'null response',
+        response: { base: null },
+        expected: { base: { string: '' } },
+        value: ''
+    }]).test('enables to load a response', (data, assert) => {
+        const ready = assert.async();
+        const $container = $(`#${fixtureContainerId}7`);
+        const buildState = response => ({ RESPONSE: { response } });
         assert.expect(5);
-
-        var $container = $('#' + fixtureContainerId + '7');
-
-        //Var $container = $('#outside-container');
-        var response = { base: { string: '<strong>test</strong>' } };
 
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', itemDataXhtml, { view: 'scorer' })
-            .on('error', function (e) {
+            .on('error', e => {
                 assert.ok(false, e);
                 ready();
             })
-            .on('render', function () {
-                var self = this;
-
+            .on('render', () => {
                 //Set the state
-                runner.setState({ RESPONSE: { response: response } });
+                runner.setState(buildState(data.response));
 
                 assert.equal(
                     $container.find('.qti-extendedTextInteraction').length,
@@ -326,22 +349,20 @@ define([
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
                 assert.deepEqual(
-                    self.getState(),
-                    { RESPONSE: { response: response } },
+                    runner.getState(),
+                    buildState(data.expected),
                     'the response state is equal to the loaded response'
                 );
 
                 //Ck set the text with a little delay
-                _.delay(function () {
+                _.delay(() => {
                     assert.equal(
                         $container.find('div.text-container')[0].innerHTML,
-                        response.base.string,
+                        data.value,
                         'the state text is inserted'
                     );
 
-                    _.delay(function () {
-                        ready();
-                    }, 10);
+                    _.delay(ready, 10);
                 }, 10);
             })
             .init()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-10

When an Extended Text interaction is set with a null response, it triggers an error. This is particularly annoying in the Test Reviewer, as empty responses are restored as null responses.

How to test:
- `npm run test`

Or see the companion PR.