### PR TITLE
Fix/TR-213/Limit the number of times a media can be played

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -216,7 +216,7 @@ function setResponse(interaction, response) {
             if (interaction.mediaElement) {
                 if (maxPlays !== 0 && maxPlays <= parseInt(timesPlayed, 10)) {
                     interaction.mediaElement.disable();
-                } else {
+                } else if (interaction.mediaElement.is('disabled')) {
                     interaction.mediaElement.enable();
                 }
             }

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -208,9 +208,18 @@ function _getRawResponse(interaction) {
 function setResponse(interaction, response) {
     if (response) {
         try {
-            //try to unserialize the pci response
+            const maxPlays = parseInt(interaction.attr('maxPlays'), 10) || 0;
             const responseValues = pciResponse.unserialize(response, interaction);
-            getContainer(interaction).data('timesPlayed', responseValues[0]);
+            const timesPlayed = responseValues[0];
+            getContainer(interaction).data('timesPlayed', timesPlayed);
+
+            if (interaction.mediaElement) {
+                if (maxPlays !== 0 && maxPlays <= parseInt(timesPlayed, 10)) {
+                    interaction.mediaElement.disable();
+                } else {
+                    interaction.mediaElement.enable();
+                }
+            }
         } catch (e) {
             // something went wrong
         }

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -208,11 +208,11 @@ function setResponse(interaction, response) {
         try {
             const maxPlays = parseInt(interaction.attr('maxPlays'), 10) || 0;
             const responseValues = pciResponse.unserialize(response, interaction);
-            const timesPlayed = responseValues[0];
+            const timesPlayed = parseInt(responseValues[0], 10);
             getContainer(interaction).data('timesPlayed', timesPlayed);
 
             if (interaction.mediaElement) {
-                if (maxPlays !== 0 && maxPlays <= parseInt(timesPlayed, 10)) {
+                if (maxPlays !== 0 && maxPlays <= timesPlayed) {
                     interaction.mediaElement.disable();
                 } else if (interaction.mediaElement.is('disabled')) {
                     interaction.mediaElement.enable();

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -149,9 +149,7 @@ function render(interaction) {
         }
 
         //initialize the component
-        $container.on('responseSet', function () {
-            initMediaPlayer();
-        });
+        $container.on('responseSet', initMediaPlayer);
 
         //gives a small chance to the responseSet event before initializing the player
         initMediaPlayer();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-213

Make sure the media player prevents playing more times when the state is restored and the limit is reached.
The file has been rewritten in ES6. Please see the commit for the actual fix.

How to test:
- checkout the companion branch on [taoQtiItem](https://github.com/oat-sa/extension-tao-itemqti/pull/1592), and run `npm i` in the views folder
- build a test containing a media interaction with a play limit, make sure to have more than one item, and set the test part as non-linear.
- take the test, play the media then navigate back and forward
- the media should not be playable when the limit is reached, even if the item is revisited

**Note:** there is a known issue, as the visual is not the same when the player is disabled once the limit is reached upon play, and when the state is restored when revisiting (in the first case the UI is removed, in the second case the UI remains but disabled)