### PR TITLE
Fix PCI in review renderer mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 
 dist
 .idea/
+
+# OS
+.DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ dist
 .idea/
 
 # OS
-.DS_STORE
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.15.2",
+    "version": "0.15.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.15.2",
+    "version": "0.15.3",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/reviewRenderer/helpers/pci.js
+++ b/src/reviewRenderer/helpers/pci.js
@@ -9,6 +9,6 @@ const interactablePcis = ['textReaderInteraction'];
  * @param {String} pciType
  * @returns {Boolean}
  */
-export const isInteractionDisabled = pciType => {
+export const isInteractionDisabledForPci = pciType => {
     return interactablePcis.indexOf(pciType) === -1;
 };

--- a/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -24,11 +24,11 @@ import template from 'taoQtiItem/reviewRenderer/tpl/interactions/customInteracti
 import portableCustomInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/PortableCustomInteraction';
 import util from 'taoQtiItem/qtiItem/helper/util';
 import PortableElement from 'taoQtiItem/qtiCommonRenderer/helpers/PortableElement';
-import { isInteractionDisabled } from 'taoQtiItem/reviewRenderer/helpers/pci';
+import { isInteractionDisabledForPci } from 'taoQtiItem/reviewRenderer/helpers/pci';
 
 const getData = (customInteraction, data) => {
     let markup = data.markup;
-    const isInteractionDisabled = isInteractionDisabled(data.typeIdentifier);
+    const isInteractionDisabled = isInteractionDisabledForPci(data.typeIdentifier);
 
     //remove ns + fix media file path
     markup = util.removeMarkupNamespaces(markup);

--- a/test/reviewRenderer/helpers/pci/test.js
+++ b/test/reviewRenderer/helpers/pci/test.js
@@ -2,8 +2,8 @@ define(['jquery', 'taoQtiItem/reviewRenderer/helpers/pci'], function ($, pci) {
     'use strict';
 
     QUnit.test('isInteractionDisabled', function (assert) {
-        const isInteractionDisabledForTextReader = pci.isInteractionDisabled('textReaderInteraction');
-        const isInteractionDisabledForAudioPci = pci.isInteractionDisabled('audioRecordingInteraction');
+        const isInteractionDisabledForTextReader = pci.isInteractionDisabledForPci('textReaderInteraction');
+        const isInteractionDisabledForAudioPci = pci.isInteractionDisabledForPci('audioRecordingInteraction');
 
         assert.ok(isInteractionDisabledForTextReader === false, 'interaction in text Reader PCI is allowed');
         assert.ok(isInteractionDisabledForAudioPci === true, 'interaction in Audio recording PCI is not allowed');


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-532

### What has changed?

- Functionality to allow interaction in specific PCIs

### how to test?

- Create a test with text reader PCI and one more PCI (don't forget to add manual scoring flags)
- Publish the test and create a scoring project
- Give the test as a TT
- Login as a scorer on MS and try to interact with both the PCIs
- You should be able to interact with text reader but not wiht any other PCIs

### Related

https://github.com/oat-sa/extension-tao-itemqti/pull/1593