### PR TITLE
fix: replace <div> with <pre> for extended text interaction in review…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -39,7 +39,7 @@ const render = interaction => {
         const placeholderText = interaction.attr('placeholderText');
 
         if (!multiple) {
-            $el = $container.find('pre.text-container');
+            $el = $container.find('.text-container');
             if (placeholderText) {
                 $el.attr('placeholder', placeholderText);
             }
@@ -51,7 +51,7 @@ const render = interaction => {
 
             //multiple inputs
         } else {
-            $el = $container.find('pre.text-container');
+            $el = $container.find('.text-container');
             minStrings = interaction.attr('minStrings');
             expectedLength = interaction.attr('expectedLength');
             patternMask = interaction.attr('patternMask');
@@ -111,9 +111,9 @@ const _getFormat = interaction => {
  */
 const _getTextContainerValue = interaction => {
     if (_getFormat(interaction) === 'xhtml') {
-        return containerHelper.get(interaction).find('pre.text-container')[0].innerHTML;
+        return containerHelper.get(interaction).find('.text-container')[0].innerHTML;
     } else {
-        return containerHelper.get(interaction).find('pre.text-container')[0].innerText;
+        return containerHelper.get(interaction).find('.text-container')[0].innerText;
     }
 };
 
@@ -217,13 +217,13 @@ const inputLimiter = interaction => {
  * @param {Object} interaction - the extended text interaction model
  */
 const resetResponse = interaction => {
-    containerHelper.get(interaction).find('pre.text-container')[0].innerText = '';
+    containerHelper.get(interaction).find('.text-container')[0].innerText = '';
 };
 
 const setText = (interaction, text) => {
     const limiter = inputLimiter(interaction);
 
-    containerHelper.get(interaction).find('pre.text-container')[0].innerHTML = text;
+    containerHelper.get(interaction).find('.text-container')[0].innerHTML = text;
 
     if (limiter.enabled) {
         limiter.updateCounter();
@@ -256,7 +256,7 @@ const getResponse = interaction => {
     if (multiple) {
         values = [];
 
-        $container.find('pre.text-container').each(i => {
+        $container.find('.text-container').each(i => {
             const $el = $(this);
 
             if (attributes.placeholderText && $el.innerText === attributes.placeholderText) {

--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -39,7 +39,7 @@ const render = interaction => {
         const placeholderText = interaction.attr('placeholderText');
 
         if (!multiple) {
-            $el = $container.find('div.text-container');
+            $el = $container.find('pre.text-container');
             if (placeholderText) {
                 $el.attr('placeholder', placeholderText);
             }
@@ -51,7 +51,7 @@ const render = interaction => {
 
             //multiple inputs
         } else {
-            $el = $container.find('div.text-container');
+            $el = $container.find('pre.text-container');
             minStrings = interaction.attr('minStrings');
             expectedLength = interaction.attr('expectedLength');
             patternMask = interaction.attr('patternMask');
@@ -111,9 +111,9 @@ const _getFormat = interaction => {
  */
 const _getTextContainerValue = interaction => {
     if (_getFormat(interaction) === 'xhtml') {
-        return containerHelper.get(interaction).find('div.text-container')[0].innerHTML;
+        return containerHelper.get(interaction).find('pre.text-container')[0].innerHTML;
     } else {
-        return containerHelper.get(interaction).find('div.text-container')[0].innerText;
+        return containerHelper.get(interaction).find('pre.text-container')[0].innerText;
     }
 };
 
@@ -217,13 +217,13 @@ const inputLimiter = interaction => {
  * @param {Object} interaction - the extended text interaction model
  */
 const resetResponse = interaction => {
-    containerHelper.get(interaction).find('div.text-container')[0].innerText = '';
+    containerHelper.get(interaction).find('pre.text-container')[0].innerText = '';
 };
 
 const setText = (interaction, text) => {
     const limiter = inputLimiter(interaction);
 
-    containerHelper.get(interaction).find('div.text-container')[0].innerHTML = text;
+    containerHelper.get(interaction).find('pre.text-container')[0].innerHTML = text;
 
     if (limiter.enabled) {
         limiter.updateCounter();
@@ -256,7 +256,7 @@ const getResponse = interaction => {
     if (multiple) {
         values = [];
 
-        $container.find('div.text-container').each(i => {
+        $container.find('pre.text-container').each(i => {
             const $el = $(this);
 
             if (attributes.placeholderText && $el.innerText === attributes.placeholderText) {

--- a/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
+++ b/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
@@ -4,7 +4,7 @@
     {{#if multiple}}
         {{#equal attributes.format "xhtml"}}
             {{#each maxStringLoop}}
-                <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" name="{{attributes.identifier}}_{{this}}" contenteditable></pre>
+                <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" name="{{attributes.identifier}}_{{this}}" contenteditable></div>
             {{/each}}
         {{else}}
             {{#each maxStringLoop}}
@@ -14,8 +14,8 @@
             {{/each}}
         {{/equal}}
     {{else}}
-        {{#equal attributes.format xhtml}}
-        <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" contenteditable></pre>
+        {{#equal attributes.format "xhtml"}}
+        <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" contenteditable></div>
         {{else}}
             <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
                     name="{{attributes.identifier}}_{{this}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"

--- a/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
+++ b/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
@@ -4,22 +4,22 @@
     {{#if multiple}}
         {{#equal attributes.format "xhtml"}}
             {{#each maxStringLoop}}
-                <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" name="{{attributes.identifier}}_{{this}}" contenteditable></div>
+                <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" name="{{attributes.identifier}}_{{this}}" contenteditable></pre>
             {{/each}}
         {{else}}
             {{#each maxStringLoop}}
-                <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
+                <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
                     name="{{attributes.identifier}}_{{this}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"
-                    {{/if}} aria-labelledby="{{promptId}}"></div>
+                    {{/if}} aria-labelledby="{{promptId}}"></pre>
             {{/each}}
         {{/equal}}
     {{else}}
         {{#equal attributes.format xhtml}}
-        <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" contenteditable></div>
+        <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" contenteditable></pre>
         {{else}}
-            <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
+            <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
                     name="{{attributes.identifier}}_{{this}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"
-                    {{/if}} aria-labelledby="{{promptId}}"></div>
+                    {{/if}} aria-labelledby="{{promptId}}"></pre>
         {{/equal}}
     {{/if}}
     <div class="text-counter">

--- a/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
+++ b/src/reviewRenderer/tpl/interactions/extendedTextInteraction.tpl
@@ -4,7 +4,7 @@
     {{#if multiple}}
         {{#equal attributes.format "xhtml"}}
             {{#each maxStringLoop}}
-                <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" name="{{attributes.identifier}}_{{this}}" contenteditable></div>
+                <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" name="{{attributes.identifier}}_{{this}}"></div>
             {{/each}}
         {{else}}
             {{#each maxStringLoop}}
@@ -15,7 +15,7 @@
         {{/equal}}
     {{else}}
         {{#equal attributes.format "xhtml"}}
-        <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}" contenteditable></div>
+        <div class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"></div>
         {{else}}
             <pre class="text-container text-{{attributes.format}} solid{{#if attributes.class}} attributes.class{{/if}}"
                     name="{{attributes.identifier}}_{{this}}" {{#if attributes.patternMask}}pattern="{{attributes.patternMask}}"

--- a/test/reviewRenderer/interactions/extendedText/test.js
+++ b/test/reviewRenderer/interactions/extendedText/test.js
@@ -126,7 +126,7 @@ define([
                 );
 
                 assert.equal(
-                    $container.find('pre.text-container')[0].innerHTML,
+                    $container.find('.text-container')[0].innerHTML,
                     data.value,
                     'the textarea displays the loaded response'
                 );
@@ -164,7 +164,7 @@ define([
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                $container.find('pre.text-container')[0].innerText = 'test';
+                $container.find('.text-container')[0].innerText = 'test';
 
                 _.delay(function () {
                     assert.deepEqual(
@@ -211,7 +211,7 @@ define([
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                $container.find('pre.text-container')[0].innerText = 'test';
+                $container.find('.text-container')[0].innerText = 'test';
 
                 _.delay(function () {
                     assert.deepEqual(
@@ -357,7 +357,7 @@ define([
                 //Ck set the text with a little delay
                 _.delay(() => {
                     assert.equal(
-                        $container.find('pre.text-container')[0].innerHTML,
+                        $container.find('.text-container')[0].innerHTML,
                         data.value,
                         'the state text is inserted'
                     );
@@ -395,7 +395,7 @@ define([
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                $container.find('pre.text-container')[0].innerHTML = response;
+                $container.find('.text-container')[0].innerHTML = response;
 
                 assert.deepEqual(
                     self.getState(),
@@ -411,7 +411,7 @@ define([
                         { RESPONSE: { response: { base: { string: '' } } } },
                         'The response is cleared'
                     );
-                    assert.equal($container.find('pre.text-container')[0].innerHTML, '', 'the editor is cleared');
+                    assert.equal($container.find('.text-container')[0].innerHTML, '', 'the editor is cleared');
 
                     _.delay(ready, 10);
                 }, 10);

--- a/test/reviewRenderer/interactions/extendedText/test.js
+++ b/test/reviewRenderer/interactions/extendedText/test.js
@@ -126,7 +126,7 @@ define([
                 );
 
                 assert.equal(
-                    $container.find('div.text-container')[0].innerHTML,
+                    $container.find('pre.text-container')[0].innerHTML,
                     data.value,
                     'the textarea displays the loaded response'
                 );
@@ -164,7 +164,7 @@ define([
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                $container.find('div.text-container')[0].innerText = 'test';
+                $container.find('pre.text-container')[0].innerText = 'test';
 
                 _.delay(function () {
                     assert.deepEqual(
@@ -211,7 +211,7 @@ define([
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                $container.find('div.text-container')[0].innerText = 'test';
+                $container.find('pre.text-container')[0].innerText = 'test';
 
                 _.delay(function () {
                     assert.deepEqual(
@@ -357,7 +357,7 @@ define([
                 //Ck set the text with a little delay
                 _.delay(() => {
                     assert.equal(
-                        $container.find('div.text-container')[0].innerHTML,
+                        $container.find('pre.text-container')[0].innerHTML,
                         data.value,
                         'the state text is inserted'
                     );
@@ -395,7 +395,7 @@ define([
                     'the container contains a text interaction .qti-extendedTextInteraction'
                 );
 
-                $container.find('div.text-container')[0].innerHTML = response;
+                $container.find('pre.text-container')[0].innerHTML = response;
 
                 assert.deepEqual(
                     self.getState(),
@@ -411,7 +411,7 @@ define([
                         { RESPONSE: { response: { base: { string: '' } } } },
                         'The response is cleared'
                     );
-                    assert.equal($container.find('div.text-container')[0].innerHTML, '', 'the editor is cleared');
+                    assert.equal($container.find('pre.text-container')[0].innerHTML, '', 'the editor is cleared');
 
                     _.delay(ready, 10);
                 }, 10);


### PR DESCRIPTION
# Pull request summary

Related to [MS-707](https://oat-sa.atlassian.net/browse/MS-707).

When TT's response contains text with multiple paragraphs it will be displayed without line breaks

# How to test

1. Create test with extended text interaction
2. Pass the test as a TT (fill in the field with multiple lines)
3. Log in as a Scorer
4. Start scoring corresponding task
5. Check that line breaks and spaces are displayed correctly

# Checklist

- [ ] New code is covered by tests (if applicable)
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful
- [ ] Pull request's target is not master
