### PR TITLE
Feature/tr 508 implement ims pci onready

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -98,16 +98,18 @@ var render = function render(interaction, options) {
                                 response: response,
                                 state: state,
                                 assetManager: assetManager
+                            }).then(instance => {
+                                //forward internal PCI event responseChange
+                                if (_.isFunction(instance.on)) {
+                                    interaction.onPci('responseChange', function () {
+                                        containerHelper.triggerResponseChangeEvent(interaction);
+                                    });
+                                }
+                                resolve();
                             });
-                            //forward internal PCI event responseChange
-                            if (_.isFunction(pci.on)) {
-                                interaction.onPci('responseChange', function () {
-                                    containerHelper.triggerResponseChangeEvent(interaction);
-                                });
-                            }
-                            return resolve();
+                        } else {
+                            reject('Unable to initialize pci "' + id + '"');
                         }
-                        return reject('Unable to initialize pci "' + id + '"');
                     },
                     reject
                 );

--- a/src/qtiCommonRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 

--- a/src/qtiCommonRenderer/renderers/interactions/pci/common.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/common.js
@@ -62,6 +62,7 @@ export default function commonPciRenderer(runtime) {
                 properties,
                 pciAssetManager
             );
+            return Promise.resolve(pci);
         },
         /**
          *

--- a/src/qtiCommonRenderer/renderers/interactions/pci/common.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/common.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
 import _ from 'lodash';

--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -23,11 +23,6 @@ import instanciator from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/pc
 
 var logger = loggerFactory('taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims');
 
-var pciReadyCallback = function pciReadyCallback(pci, state) {
-    //standard callback function to be implemented in a future story
-    logger.info('pciReadyCallback called on PCI ' + pci.typeIdentifier);
-};
-
 var pciDoneCallback = function pciDoneCallback(pci, response, state, status) {
     //standard callback function to be implemented in a future story
     logger.info('pciDoneCallback called on PCI ' + pci.typeIdentifier);
@@ -53,6 +48,11 @@ export default function defaultPciRenderer(runtime) {
                 properties[propKey] = _.isArray(propVal) || _.isObject(propVal) ? JSON.stringify(propVal) : propVal;
             });
 
+            let pciReadyCallback;
+            const readyPromise = new Promise(resolve => {
+                pciReadyCallback = resolve;
+            });
+
             config = {
                 properties: properties,
                 templateVariables: {}, //not supported yet
@@ -63,6 +63,11 @@ export default function defaultPciRenderer(runtime) {
             };
 
             pci.getInstance(containerHelper.get(interaction).get(0), config, context.state);
+
+            return readyPromise.then(instance => {
+                instanciator.setPci(interaction, instance);
+                return instance;
+            });
         },
         destroy: function destroy(interaction) {
             instanciator.getPci(interaction).oncompleted();

--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
 import _ from 'lodash';

--- a/src/qtiCommonRenderer/renderers/interactions/pci/instanciator.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/instanciator.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technlogies SA (under the project TAO-PRODUCT);
  *
  */
 import qtiCustomInteractionContext from 'qtiCustomInteractionContext';
@@ -26,9 +26,9 @@ export default {
      * @param {Object} interaction - the js object representing the interaction
      * @returns {Object} PCI instance
      */
-    getPci: function getPci(interaction) {
-        var pciTypeIdentifier,
-            pci = interaction.data('pci');
+    getPci(interaction) {
+        let pciTypeIdentifier;
+        let pci = interaction.data('pci');
 
         if (!pci) {
             pciTypeIdentifier = interaction.typeIdentifier;
@@ -43,5 +43,14 @@ export default {
         }
 
         return pci;
+    },
+
+    /**
+     * Associate a PCI instance to the interaction object
+     * @param {*} interaction 
+     * @param {*} instance 
+     */
+    setPci(interaction, instance) {
+        interaction.data('pci', instance);
     }
 };

--- a/src/qtiCommonRenderer/renderers/interactions/pci/instanciator.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/instanciator.js
@@ -47,8 +47,8 @@ export default {
 
     /**
      * Associate a PCI instance to the interaction object
-     * @param {*} interaction 
-     * @param {*} instance 
+     * @param {Object} interaction - the js object representing the interaction
+     * @param {Object} instance - PCI instance
      */
     setPci(interaction, instance) {
         interaction.data('pci', instance);

--- a/src/qtiItem/core/interactions/CustomInteraction.js
+++ b/src/qtiItem/core/interactions/CustomInteraction.js
@@ -1,3 +1,21 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * 
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
 import _ from 'lodash';
 import Interaction from 'taoQtiItem/qtiItem/core/interactions/Interaction';
 import CustomElement from 'taoQtiItem/qtiItem/mixin/CustomElement';

--- a/src/qtiItem/core/interactions/CustomInteraction.js
+++ b/src/qtiItem/core/interactions/CustomInteraction.js
@@ -11,7 +11,7 @@ var CustomInteraction = Interaction.extend({
     nsUriFragment: 'portableCustomInteraction',
     defaultMarkupNsName: 'html5',
     defaultMarkupNsUri: 'html5',
-    init: function (serial, attributes) {
+    init: function(serial, attributes) {
         this._super(serial, attributes);
 
         this.typeIdentifier = '';
@@ -26,10 +26,10 @@ var CustomInteraction = Interaction.extend({
 
         this.pciReadyCallbacks = [];
     },
-    is: function (qtiClass) {
+    is: function(qtiClass) {
         return qtiClass === 'customInteraction' || this._super(qtiClass);
     },
-    render: function () {
+    render: function() {
         var args = rendererConfig.getOptionsFromArguments(arguments),
             renderer = args.renderer || this.getRenderer(),
             defaultData = {
@@ -45,13 +45,13 @@ var CustomInteraction = Interaction.extend({
 
         return this._super(_.merge(defaultData, args.data), args.placeholder, args.subclass, renderer);
     },
-    toArray: function () {
+    toArray: function() {
         var arr = this._super();
         arr.markup = this.markup;
         arr.properties = this.properties;
         return arr;
     },
-    getMarkupNamespace: function () {
+    getMarkupNamespace: function() {
         if (this.markupNs && this.markupNs.name && this.markupNs.uri) {
             return _.clone(this.markupNs);
         } else {
@@ -68,13 +68,13 @@ var CustomInteraction = Interaction.extend({
 
         return {};
     },
-    setMarkupNamespace: function (name, uri) {
+    setMarkupNamespace: function(name, uri) {
         this.markupNs = {
             name: name,
             uri: uri
         };
     },
-    onPciReady: function (callback) {
+    onPciReady: function(callback) {
         this.pciReadyCallbacks.push(callback);
 
         if (this.data('pci')) {
@@ -82,12 +82,12 @@ var CustomInteraction = Interaction.extend({
             this.triggerPciReady();
         }
     },
-    triggerPciReady: function () {
+    triggerPciReady: function() {
         var _this = this,
             pci = this.data('pci');
 
         if (pci) {
-            _.each(this.pciReadyCallbacks, function (fn) {
+            _.each(this.pciReadyCallbacks, function(fn) {
                 fn.call(_this, pci);
             });
 
@@ -100,8 +100,8 @@ var CustomInteraction = Interaction.extend({
             throw 'cannot trigger pci ready when no pci is actually attached to the interaction';
         }
     },
-    onPci: function (event, callback) {
-        this.onPciReady(function (pci) {
+    onPci: function(event, callback) {
+        this.onPciReady(function(pci) {
             if (_.isFunction(pci.on)) {
                 pci.on(event, callback);
             } else {
@@ -110,8 +110,8 @@ var CustomInteraction = Interaction.extend({
         });
         return this;
     },
-    offPci: function (event) {
-        this.onPciReady(function (pci) {
+    offPci: function(event) {
+        this.onPciReady(function(pci) {
             if (_.isFunction(pci.off)) {
                 pci.off(event);
             } else {
@@ -120,8 +120,8 @@ var CustomInteraction = Interaction.extend({
         });
         return this;
     },
-    triggerPci: function (event, args) {
-        this.onPciReady(function (pci) {
+    triggerPci: function(event, args) {
+        this.onPciReady(function(pci) {
             if (_.isFunction(pci.off)) {
                 pci.trigger(event, args);
             } else {

--- a/src/qtiItem/core/interactions/CustomInteraction.js
+++ b/src/qtiItem/core/interactions/CustomInteraction.js
@@ -1,21 +1,3 @@
-/**
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; under version 2
- * of the License (non-upgradable).
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
- */
-
 import _ from 'lodash';
 import Interaction from 'taoQtiItem/qtiItem/core/interactions/Interaction';
 import CustomElement from 'taoQtiItem/qtiItem/mixin/CustomElement';
@@ -29,7 +11,7 @@ var CustomInteraction = Interaction.extend({
     nsUriFragment: 'portableCustomInteraction',
     defaultMarkupNsName: 'html5',
     defaultMarkupNsUri: 'html5',
-    init: function(serial, attributes) {
+    init: function (serial, attributes) {
         this._super(serial, attributes);
 
         this.typeIdentifier = '';
@@ -44,10 +26,10 @@ var CustomInteraction = Interaction.extend({
 
         this.pciReadyCallbacks = [];
     },
-    is: function(qtiClass) {
+    is: function (qtiClass) {
         return qtiClass === 'customInteraction' || this._super(qtiClass);
     },
-    render: function() {
+    render: function () {
         var args = rendererConfig.getOptionsFromArguments(arguments),
             renderer = args.renderer || this.getRenderer(),
             defaultData = {
@@ -63,13 +45,13 @@ var CustomInteraction = Interaction.extend({
 
         return this._super(_.merge(defaultData, args.data), args.placeholder, args.subclass, renderer);
     },
-    toArray: function() {
+    toArray: function () {
         var arr = this._super();
         arr.markup = this.markup;
         arr.properties = this.properties;
         return arr;
     },
-    getMarkupNamespace: function() {
+    getMarkupNamespace: function () {
         if (this.markupNs && this.markupNs.name && this.markupNs.uri) {
             return _.clone(this.markupNs);
         } else {
@@ -86,13 +68,13 @@ var CustomInteraction = Interaction.extend({
 
         return {};
     },
-    setMarkupNamespace: function(name, uri) {
+    setMarkupNamespace: function (name, uri) {
         this.markupNs = {
             name: name,
             uri: uri
         };
     },
-    onPciReady: function(callback) {
+    onPciReady: function (callback) {
         this.pciReadyCallbacks.push(callback);
 
         if (this.data('pci')) {
@@ -100,12 +82,12 @@ var CustomInteraction = Interaction.extend({
             this.triggerPciReady();
         }
     },
-    triggerPciReady: function() {
+    triggerPciReady: function () {
         var _this = this,
             pci = this.data('pci');
 
         if (pci) {
-            _.each(this.pciReadyCallbacks, function(fn) {
+            _.each(this.pciReadyCallbacks, function (fn) {
                 fn.call(_this, pci);
             });
 
@@ -118,8 +100,8 @@ var CustomInteraction = Interaction.extend({
             throw 'cannot trigger pci ready when no pci is actually attached to the interaction';
         }
     },
-    onPci: function(event, callback) {
-        this.onPciReady(function(pci) {
+    onPci: function (event, callback) {
+        this.onPciReady(function (pci) {
             if (_.isFunction(pci.on)) {
                 pci.on(event, callback);
             } else {
@@ -128,8 +110,8 @@ var CustomInteraction = Interaction.extend({
         });
         return this;
     },
-    offPci: function(event) {
-        this.onPciReady(function(pci) {
+    offPci: function (event) {
+        this.onPciReady(function (pci) {
             if (_.isFunction(pci.off)) {
                 pci.off(event);
             } else {
@@ -138,8 +120,8 @@ var CustomInteraction = Interaction.extend({
         });
         return this;
     },
-    triggerPci: function(event, args) {
-        this.onPciReady(function(pci) {
+    triggerPci: function (event, args) {
+        this.onPciReady(function (pci) {
             if (_.isFunction(pci.off)) {
                 pci.trigger(event, args);
             } else {

--- a/test/qtiCommonRenderer/interactions/pci/common/qtiCustomInteractionContextMock.js
+++ b/test/qtiCommonRenderer/interactions/pci/common/qtiCustomInteractionContextMock.js
@@ -1,0 +1,29 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+define('qtiCustomInteractionContext', [], function () {
+    return {
+        createPciInstance: function (typeIdentifier) {
+            return {
+                typeIdentifier,
+                initialize(id, dom, properties, assetManager) {
+                    this.initializeParameters = { id, dom, properties, assetManager };
+                }
+            };
+        }
+    };
+});

--- a/test/qtiCommonRenderer/interactions/pci/common/test.html
+++ b/test/qtiCommonRenderer/interactions/pci/common/test.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Common</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function () {
+                require(['qunitEnv'], function () {
+                    define('qtiCustomInteractionContext', [], function () {
+                        return {
+                            createPciInstance: function (typeIdentifier) {
+                                return {
+                                    typeIdentifier,
+                                    initialize(id, dom, properties, assetManager) {
+                                        this.initializeParameters = { id, dom, properties, assetManager };
+                                    }
+                                };
+                            }
+                        };
+                    });
+                    define('taoQtiItem/qtiCommonRenderer/helpers/container', function () {
+                        return {
+                            get(interaction) {
+                                return {
+                                    children() {
+                                        return {
+                                            get() {
+                                                return 'dom for interaction';
+                                            }
+                                        };
+                                    }
+                                };
+                            }
+                        };
+                    });
+                    require(['taoQtiItem/test/qtiCommonRenderer/interactions/pci/common/test'], function () {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/qtiCommonRenderer/interactions/pci/common/test.html
+++ b/test/qtiCommonRenderer/interactions/pci/common/test.html
@@ -6,19 +6,12 @@
         <script type="text/javascript" src="/environment/require.js"></script>
         <script type="text/javascript">
             require(['/environment/config.js'], function () {
+                requirejs.config({
+                    paths: {
+                        qtiCustomInteractionContext: '/test/qtiCommonRenderer/interactions/pci/common/qtiCustomInteractionContextMock'
+                    }
+                });
                 require(['qunitEnv'], function () {
-                    define('qtiCustomInteractionContext', [], function () {
-                        return {
-                            createPciInstance: function (typeIdentifier) {
-                                return {
-                                    typeIdentifier,
-                                    initialize(id, dom, properties, assetManager) {
-                                        this.initializeParameters = { id, dom, properties, assetManager };
-                                    }
-                                };
-                            }
-                        };
-                    });
                     define('taoQtiItem/qtiCommonRenderer/helpers/container', function () {
                         return {
                             get(interaction) {

--- a/test/qtiCommonRenderer/interactions/pci/common/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/common/test.js
@@ -1,0 +1,67 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/common'], function (common) {
+    'use strict';
+
+    QUnit.test('createInstance', function (assert) {
+        const done = assert.async();
+
+        const typeIdentifier = 'foo';
+        const properties = {
+            bar: 'baz'
+        };
+        const interaction = {
+            _store: {},
+            attr() {
+                return typeIdentifier;
+            },
+            properties,
+            data(key, data) {
+                if (typeof data === 'undefined') {
+                    return this._store[key];
+                }
+                this._store[key] = data;
+            }
+        };
+        const response = { base: null };
+        const context = { response };
+
+        const instancePromise = common().createInstance(interaction, context);
+
+        assert.ok(instancePromise instanceof Promise, 'createInstance returns with a Promise');
+
+        instancePromise.then(instance => {
+            assert.propEqual(
+                instance.initializeParameters,
+                {
+                    assetManager: {
+                        resolve: {}
+                    },
+                    dom: 'dom for interaction',
+                    id: 'foo',
+                    properties: {
+                        bar: 'baz'
+                    }
+                },
+                'passes correct parameters to pci'
+            );
+            done();
+        });
+    });
+});

--- a/test/qtiCommonRenderer/interactions/pci/ims/test.html
+++ b/test/qtiCommonRenderer/interactions/pci/ims/test.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>IMS</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function () {
+                require(['qunitEnv'], function () {
+                    define('qtiCustomInteractionContext', [], function () {
+                        return {
+                            createPciInstance: function (typeIdentifier) {
+                                return {
+                                    typeIdentifier,
+                                    getInstance(dom, config) {
+                                        config.onready({
+                                            typeIdentifier,
+                                            dom,
+                                            config
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                    });
+                    define('taoQtiItem/qtiCommonRenderer/helpers/container', function () {
+                        return {
+                            get(interaction) {
+                                return {
+                                    get() {
+                                        return 'dom for interaction';
+                                    }
+                                };
+                            }
+                        };
+                    });
+                    require(['taoQtiItem/test/qtiCommonRenderer/interactions/pci/ims/test'], function () {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/qtiCommonRenderer/interactions/pci/ims/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/ims/test.js
@@ -1,0 +1,67 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function (ims) {
+    'use strict';
+
+    QUnit.test('createInstance', function (assert) {
+        const done = assert.async();
+
+        const typeIdentifier = 'foo';
+        const properties = {
+            bar: 'baz'
+        };
+        const interaction = {
+            _store: {},
+            typeIdentifier,
+            properties,
+            data(key, data) {
+                if (typeof data === 'undefined') {
+                    return this._store[key];
+                }
+                this._store[key] = data;
+            }
+        };
+        const response = { base: null };
+        const context = { response };
+
+        const instancePromise = ims().createInstance(interaction, context);
+
+        assert.ok(instancePromise instanceof Promise, 'createInstance returns with a Promise');
+
+        instancePromise.then(instance => {
+            assert.propEqual(
+                instance,
+                {
+                    typeIdentifier,
+                    dom: 'dom for interaction',
+                    config: {
+                        boundTo: response,
+                        ondone: {},
+                        onready: {},
+                        properties,
+                        status: 'interacting',
+                        templateVariables: {}
+                    }
+                },
+                'passes correct parameters to ims pci'
+            );
+            done();
+        });
+    });
+});

--- a/test/qtiCommonRenderer/interactions/pci/instanciator/test.html
+++ b/test/qtiCommonRenderer/interactions/pci/instanciator/test.html
@@ -5,18 +5,18 @@
         <title>Instanciator test</title>
         <script type="text/javascript" src="/environment/require.js"></script>
         <script type="text/javascript">
-            require(['/environment/config.js'], function() {
-                require(['qunitEnv'], function() {
-                    define('qtiCustomInteractionContext', [], function() {
+            require(['/environment/config.js'], function () {
+                require(['qunitEnv'], function () {
+                    define('qtiCustomInteractionContext', [], function () {
                         return {
-                            createPciInstance: function(pciTypeIdentifier) {
+                            createPciInstance: function (pciTypeIdentifier) {
                                 return {
                                     typeIdentifier: pciTypeIdentifier
                                 };
                             }
                         };
                     });
-                    require(['taoQtiItem/test/qtiCommonRenderer/interactions/pci/instanciator/test'], function() {
+                    require(['taoQtiItem/test/qtiCommonRenderer/interactions/pci/instanciator/test'], function () {
                         QUnit.start();
                     });
                 });
@@ -25,7 +25,6 @@
     </head>
     <body>
         <div id="qunit"></div>
-        <div id="qunit-fixture">
-        </div>
+        <div id="qunit-fixture"></div>
     </body>
 </html>

--- a/test/qtiCommonRenderer/interactions/pci/instanciator/test.html
+++ b/test/qtiCommonRenderer/interactions/pci/instanciator/test.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Select Point Interaction Test</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    define('qtiCustomInteractionContext', [], function() {
+                        return {
+                            createPciInstance: function(pciTypeIdentifier) {
+                                return {
+                                    typeIdentifier: pciTypeIdentifier
+                                };
+                            }
+                        };
+                    });
+                    require(['taoQtiItem/test/qtiCommonRenderer/interactions/pci/instanciator/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+        </div>
+    </body>
+</html>

--- a/test/qtiCommonRenderer/interactions/pci/instanciator/test.html
+++ b/test/qtiCommonRenderer/interactions/pci/instanciator/test.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <title>Select Point Interaction Test</title>
+        <title>Instanciator test</title>
         <script type="text/javascript" src="/environment/require.js"></script>
         <script type="text/javascript">
             require(['/environment/config.js'], function() {

--- a/test/qtiCommonRenderer/interactions/pci/instanciator/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/instanciator/test.js
@@ -41,7 +41,7 @@ define([
         
         const pci = instanciator.getPci(this.interaction);
         
-        assert.strictEqual(pci.typeIdentifier, typeIdentifier);
+        assert.strictEqual(pci.typeIdentifier, typeIdentifier, 'returns with newly created pci instance');
     });
 
     QUnit.test('instanciator returns with same pci instance on second time', function(assert) {
@@ -51,7 +51,7 @@ define([
         const pci1 = instanciator.getPci(this.interaction);
         const pci2 = instanciator.getPci(this.interaction);
         
-        assert.strictEqual(pci1, pci2);
+        assert.strictEqual(pci1, pci2, 'returns with saved pci on second time, without create new one');
     });
 
     QUnit.test('instanciator returns with set pci instance', function(assert) {
@@ -61,6 +61,6 @@ define([
 
         instanciator.setPci(this.interaction, pciInstance);
 
-        assert.strictEqual(instanciator.getPci(this.interaction), pciInstance);
+        assert.strictEqual(instanciator.getPci(this.interaction), pciInstance, 'return with previously set pci');
     });
 });

--- a/test/qtiCommonRenderer/interactions/pci/instanciator/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/instanciator/test.js
@@ -3,22 +3,20 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
 
-define([
-    'taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/instanciator',
-], function(instanciator) {
+define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/instanciator'], function (instanciator) {
     'use strict';
 
     QUnit.module('Instanciator', {
@@ -35,26 +33,26 @@ define([
         }
     });
 
-    QUnit.test('instanciator creates pci instance on first time', function(assert) {
+    QUnit.test('instanciator creates pci instance on first time', function (assert) {
         const typeIdentifier = 'pciTypeIdentifier';
         this.interaction.typeIdentifier = typeIdentifier;
-        
+
         const pci = instanciator.getPci(this.interaction);
-        
+
         assert.strictEqual(pci.typeIdentifier, typeIdentifier, 'returns with newly created pci instance');
     });
 
-    QUnit.test('instanciator returns with same pci instance on second time', function(assert) {
+    QUnit.test('instanciator returns with same pci instance on second time', function (assert) {
         const typeIdentifier = 'foo';
         this.interaction.typeIdentifier = typeIdentifier;
 
         const pci1 = instanciator.getPci(this.interaction);
         const pci2 = instanciator.getPci(this.interaction);
-        
+
         assert.strictEqual(pci1, pci2, 'returns with saved pci on second time, without create new one');
     });
 
-    QUnit.test('instanciator returns with set pci instance', function(assert) {
+    QUnit.test('instanciator returns with set pci instance', function (assert) {
         const pciInstance = {
             typeIdentifier: 'bar'
         };

--- a/test/qtiCommonRenderer/interactions/pci/instanciator/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/instanciator/test.js
@@ -1,0 +1,66 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * 
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+define([
+    'taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/instanciator',
+], function(instanciator) {
+    'use strict';
+
+    QUnit.module('Instanciator', {
+        beforeEach: function () {
+            this.interaction = {
+                _store: {},
+                data(key, data) {
+                    if (typeof data === 'undefined') {
+                        return this._store[key];
+                    }
+                    this._store[key] = data;
+                }
+            };
+        }
+    });
+
+    QUnit.test('instanciator creates pci instance on first time', function(assert) {
+        const typeIdentifier = 'pciTypeIdentifier';
+        this.interaction.typeIdentifier = typeIdentifier;
+        
+        const pci = instanciator.getPci(this.interaction);
+        
+        assert.strictEqual(pci.typeIdentifier, typeIdentifier);
+    });
+
+    QUnit.test('instanciator returns with same pci instance on second time', function(assert) {
+        const typeIdentifier = 'foo';
+        this.interaction.typeIdentifier = typeIdentifier;
+
+        const pci1 = instanciator.getPci(this.interaction);
+        const pci2 = instanciator.getPci(this.interaction);
+        
+        assert.strictEqual(pci1, pci2);
+    });
+
+    QUnit.test('instanciator returns with set pci instance', function(assert) {
+        const pciInstance = {
+            typeIdentifier: 'bar'
+        };
+
+        instanciator.setPci(this.interaction, pciInstance);
+
+        assert.strictEqual(instanciator.getPci(this.interaction), pciInstance);
+    });
+});


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-508

- Make pci creator asynchronous
- Implement IMS onready function
- create `setPCI` function for `instanciator`

Test:
- npm run test
- Integrate into tao:
  - in case of Tao PCI, it should behave like before
  - in case of IMS PCI, it should wait for `onready` call and save that as instance