### PR TITLE
fix/CON-622/ Fix unit tests, update "interactjs" to v1.3.4

### DIFF
--- a/environment/config.js
+++ b/environment/config.js
@@ -41,7 +41,9 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
 
             /* LIBS */
             'lib/simulator': '/node_modules/@oat-sa/tao-core-shared-libs/lib/simulator',
-            ckeditor: '/node_modules/@oat-sa/tao-core-shared-libs/lib/ckeditor/ckeditor'
+            ckeditor: '/node_modules/@oat-sa/tao-core-shared-libs/lib/ckeditor/ckeditor',
+            select2: '/node_modules/@oat-sa/tao-core-libs/dist/select2',
+            'select2-origin': '/node_modules/select2'
             /* LIBS END */
         }, libPathDefinition),
         shim: {
@@ -53,6 +55,9 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
             },
             ckeditor: {
                 exports: 'CKEDITOR'
+            },
+            select2 : {
+                deps: ['jquery']
             }
         },
         waitSeconds: 15

--- a/environment/config.js
+++ b/environment/config.js
@@ -38,12 +38,12 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
             'taoItems/runner': '/node_modules/@oat-sa/tao-item-runner/dist/runner',
             'taoItems/assets': '/node_modules/@oat-sa/tao-item-runner/dist/assets',
             'taoItems/scoring': '/node_modules/@oat-sa/tao-item-runner/dist/scoring',
+            Raphael: '/node_modules/raphael/raphael',
 
             /* LIBS */
             'lib/simulator': '/node_modules/@oat-sa/tao-core-shared-libs/lib/simulator',
             ckeditor: '/node_modules/@oat-sa/tao-core-shared-libs/lib/ckeditor/ckeditor',
-            select2: '/node_modules/@oat-sa/tao-core-libs/dist/select2',
-            'select2-origin': '/node_modules/select2'
+            select2: '/node_modules/@oat-sa/tao-core-libs/dist/select2'
             /* LIBS END */
         }, libPathDefinition),
         shim: {
@@ -60,7 +60,12 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
                 deps: ['jquery']
             }
         },
-        waitSeconds: 15
+        waitSeconds: 15,
+        map: {
+            '*': {
+                'raphael': 'Raphael'
+            }
+        }
     });
 
     define('qunitLibs', ['qunit', 'css!qunitStyle']);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1712,9 +1712,9 @@
             }
         },
         "interactjs": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.2.8.tgz",
-            "integrity": "sha1-8o2cawgwE9quPHfwJiBPndGYPtk=",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.3.4.tgz",
+            "integrity": "sha512-AQ2CdPEyHqiEEQ1FFgMBj79UEsU1+rUwSXuhOkflvB65p4iECft28SN/PvhD/Y9OtNge8aH1qTibjAi+RXQMqQ==",
             "dev": true
         },
         "invariant": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.17.2",
+    "version": "0.17.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "gamp": "^0.2.1",
         "glob": "^7.1.4",
         "handlebars": "1.3.0",
-        "interactjs": "1.2.8",
+        "interactjs": "1.3.4",
         "jquery": "1.9.1",
         "lodash": "2.4.1",
         "moment": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.17.2",
+    "version": "0.17.3",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/test/qtiCommonRenderer/interactions/graphicGapMatch/test.js
+++ b/test/qtiCommonRenderer/interactions/graphicGapMatch/test.js
@@ -399,24 +399,17 @@ define([
                 var interaction = this._item.getInteractions()[0];
                 interaction.renderer.destroy(interaction);
 
-                var $gapFiller = $('.qti-choice[data-identifier="gapimg_1"]', $container);
-                var $hotspot = $('.main-image-box rect', $container).eq(5);
+                var $image = $('.main-image-box', $container);
 
                 interactUtils.tapOn(
-                    $gapFiller,
+                    $image,
                     function() {
-                        interactUtils.tapOn(
-                            $hotspot,
-                            function() {
-                                assert.deepEqual(
-                                    self.getState(),
-                                    { RESPONSE: { response: { list: { directedPair: [] } } } },
-                                    'Click does not trigger response once destroyed'
-                                );
-                                ready();
-                            },
-                            10
+                        assert.deepEqual(
+                            self.getState(),
+                            { RESPONSE: { response: { list: { directedPair: [] } } } },
+                            'Click does not trigger response once destroyed'
                         );
+                        ready();
                     },
                     10
                 );

--- a/test/qtiCommonRenderer/interactions/selectPoint/qti.json
+++ b/test/qtiCommonRenderer/interactions/selectPoint/qti.json
@@ -121,7 +121,7 @@
     "responseProcessing": {
         "serial": "response_templatesdriven_589665703f539403159372",
         "qtiClass": "responseProcessing",
-        "attributes": [],
+        "attributes": {},
         "debug": {
             "relatedItem": "item_589665700e6aa547084007"
         },


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-622

1. Updated "interactjs" to v1.3.4, because tao-core-ui uses "interactjs": "1.3.4"
https://github.com/oat-sa/tao-core-ui-fe/blob/6ff2aa4ac23dbc92abc59ac92bc63bfa5c9e0e4c/package.json#L62
2. Updated configs for select2

How to test:
- run `npm run test`
- all test should pass