### PR TITLE
Fix/tr 663 restore ims pci state in review mode

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -98,15 +98,16 @@ export default function defaultPciRenderer(runtime) {
             instanciator.getPci(interaction).oncompleted();
         },
         /**
-         * IMS PCI does not have setState, so PCI should be restored and recreated with new state.
+         * IMS PCI does not have setState, so PCI should be destroyed and reinstanciated with response.
          * This function should run only in review mode.
          * @param {Object} interaction
          * @param {Object} state - state that should be set
          */
-        setState(interaction, state) {
+        setReviewState(interaction, state) {
             this.destroy(interaction);
-            this.createInstance(interaction, { state });
+            this.createInstance(interaction, { response: { RESPONSE: state.response } });
         },
+        setState: _.noop,
         getState(interaction) {
             return instanciator.getPci(interaction).getState();
         }

--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -102,10 +102,11 @@ export default function defaultPciRenderer(runtime) {
          * This function should run only in review mode.
          * @param {Object} interaction
          * @param {Object} state - state that should be set
+         * @returns {Promise<Object>} - Resolves with newly created instance
          */
         setReviewState(interaction, state) {
             this.destroy(interaction);
-            this.createInstance(interaction, { response: { RESPONSE: state.response } });
+            return this.createInstance(interaction, { response: { RESPONSE: state.response } });
         },
         setState: _.noop,
         getState(interaction) {

--- a/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -37,4 +37,15 @@ const getData = (customInteraction, data) => {
     return Object.assign({}, data, { markup, isInteractionDisabled });
 };
 
-export default Object.assign({}, portableCustomInteraction, { template, getData });
+const setState = (interaction, serializedState) => {
+    const pciRenderer = interaction.data('pci-renderer');
+
+    // IMS renderer has a special function to restore response
+    if (typeof pciRenderer.setReviewState === 'function') {
+        pciRenderer.setReviewState(interaction, serializedState);
+    } else {
+        pciRenderer.setState(interaction, serializedState);
+    }
+};
+
+export default Object.assign({}, portableCustomInteraction, { template, getData, setState });

--- a/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -37,6 +37,11 @@ const getData = (customInteraction, data) => {
     return Object.assign({}, data, { markup, isInteractionDisabled });
 };
 
+/**
+ * Set back response for review mode
+ * @param {Object} interaction 
+ * @param {Object} serializedState 
+ */
 const setState = (interaction, serializedState) => {
     const pciRenderer = interaction.data('pci-renderer');
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-663

- Save IMS PCI constructor for later use
- Create IMS PCI set review state function, that destroys PCI instance and reinstantiate PCI with new response
- Write tests for setReviewState

Test:
- Integrate `taoOutcomeUi` branch: https://github.com/oat-sa/extension-tao-outcomeui/pull/368
- Create a test with a PCI and take it
- Go to Result page and check the item review mode with the PCI.
- The previous response should be restored.