### PR TITLE
Hotfix/TR-907/Fix release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.0+1",
+    "version": "0.13.0-1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.13.0+1",
+    "version": "0.13.0-1",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-907

Set the release version for the hotfix using a pre-release suffix instead of a build as the build number is not making any difference with the main version