### PR TITLE
Fix unit test with default export problem

### DIFF
--- a/src/scoring/processor/expressions/engine.js
+++ b/src/scoring/processor/expressions/engine.js
@@ -130,7 +130,8 @@ var expressionEngineFactory = function expressionEngineFactory(state) {
 
 //register all processors
 _.forEach(expressionProcessors, function(expressionProcessor, name) {
-    processorFactory.register(name, processorFactory.types.EXPRESSION, expressionProcessor);
+    const shortName = name.replace(/Processor$/, '');
+    processorFactory.register(shortName, processorFactory.types.EXPRESSION, expressionProcessor);
 });
 _.forEach(operatorProcessors, function(operatorProcessor, name) {
     processorFactory.register(name, processorFactory.types.OPERATOR, operatorProcessor);

--- a/src/scoring/processor/expressions/engine.js
+++ b/src/scoring/processor/expressions/engine.js
@@ -129,9 +129,9 @@ var expressionEngineFactory = function expressionEngineFactory(state) {
 };
 
 //register all processors
-_.forEach(expressionProcessors, function(expressionProcessor, name) {
-    const shortName = name.replace(/Processor$/, '');
-    processorFactory.register(shortName, processorFactory.types.EXPRESSION, expressionProcessor);
+_.forEach(expressionProcessors, function(expressionProcessor, nameWithSuffix) {
+    const name = nameWithSuffix.replace(/Processor$/, '');
+    processorFactory.register(name, processorFactory.types.EXPRESSION, expressionProcessor);
 });
 _.forEach(operatorProcessors, function(operatorProcessor, name) {
     processorFactory.register(name, processorFactory.types.OPERATOR, operatorProcessor);

--- a/src/scoring/processor/expressions/expressions.js
+++ b/src/scoring/processor/expressions/expressions.js
@@ -39,7 +39,7 @@ import variable from 'taoQtiItem/scoring/processor/expressions/variable';
 /**
  * An ExpressionProcessor
  * @typedef ExpressionProcessor
- * @property {Object} exression - the expression definition
+ * @property {Object} expression - the expression definition
  * @property {Object} preProcessor - helps you to parse and manipulate values
  * @property {Object} state - the session state (responses and variables)
  * @property {Funtion} process - the processing
@@ -47,17 +47,18 @@ import variable from 'taoQtiItem/scoring/processor/expressions/variable';
 
 /**
  * Lists all available expression processors
+ * Suffix 'Processor' added to keys here otherwise ES6 thinks property 'default' is an export inside the export
  * @exports taoQtiItem/scoring/processor/expressions/expressions
  */
 export default {
-    'baseValue': baseValue,
-    'correct': correct,
-    'default': defaultt,
-    'mapResponse': mapResponse,
-    'mapResponsePoint': mapResponsePoint,
-    'mathConstant': mathConstant,
-    'null': nulll,
-    'randomFloat': randomFloat,
-    'randomInteger': randomInteger,
-    'variable': variable
+    baseValueProcessor: baseValue,
+    correctProcessor: correct,
+    defaultProcessor: defaultt,
+    mapResponseProcessor: mapResponse,
+    mapResponsePointProcessor: mapResponsePoint,
+    mathConstantProcessor: mathConstant,
+    nullProcessor: nulll,
+    randomFloatProcessor: randomFloat,
+    randomIntegerProcessor: randomInteger,
+    variableProcessor: variable
 };


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2

There was a problem with the import of this module `src/scoring/processor/expressions/expressions`. After some dependencies update in #178 (judging from the package-lock of that PR it could be something in Babel), unit test now fails because the importing file loads the `'default'` property of the exported object, instead of the whole object.
```
export default { // <-- when trying to load this one,
    'baseValue': baseValue,
    'correct': correct,
    'default': defaultt // <-- this one is loaded instead
}
```
**Fix:** add `'Processor'` suffix to the object keys and remove it at the other end. I've checked all `oat-sa` on Github and didn't find another import of the changed module. Even so, this could be released as a breaking change, to be safer.

**Test:** `npm run build` followed by  `npm run test` or `npx qunit-testrunner --keepAlive`