### PR TITLE
fix/TR-1131_call-sizeadapt-after-styles-were-applied

### DIFF
--- a/src/qtiCommonRenderer/helpers/sizeAdapter.js
+++ b/src/qtiCommonRenderer/helpers/sizeAdapter.js
@@ -51,7 +51,9 @@ export default {
                 'load',
                 function(e) {
                     if (e.target.rel === 'stylesheet') {
-                        adaptSize.height($elements);
+                        setTimeout(function () {
+                            adaptSize.height($elements);
+                        }, 300);
                     }
                 },
                 true

--- a/src/qtiCommonRenderer/helpers/sizeAdapter.js
+++ b/src/qtiCommonRenderer/helpers/sizeAdapter.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2021 (original work) Open Assessment Technologies SA;
  *
  */
 import $ from 'jquery';
@@ -26,7 +26,7 @@ export default {
      *
      * @param {jQueryElement|widget} target
      */
-    adaptSize: function(target) {
+    adaptSize: function (target) {
         var $elements;
         var $container;
 
@@ -40,20 +40,19 @@ export default {
             // jquery elements
             default:
                 $elements = target;
-                $container = $($elements)
-                    .first()
-                    .parent();
+                $container = $($elements).first().parent();
         }
 
-        $container.waitForMedia(function() {
+        $container.waitForMedia(function () {
             adaptSize.height($elements);
             document.addEventListener(
                 'load',
-                function(e) {
+                function (e) {
                     if (e.target.rel === 'stylesheet') {
-                        setTimeout(function () {
+                        // give time to slower computers to apply loaded styles
+                        setTimeout(() => {
                             adaptSize.height($elements);
-                        }, 300);
+                        }, 0);
                     }
                 },
                 true


### PR DESCRIPTION
Related to [TR-1131](https://oat-sa.atlassian.net/browse/TR-1131)

There is an issue with the height of simple choices, it's showing to height. We have check to block css files in order to test any effect in layout rendering. It shows the layout is applying the js height but no the css files, so we decided to force the item loaded in order to wait until all css files are fully applied. 

Test:
To check it is necessary a slow computer or force to load the css after the page is loaded.