### PR TITLE
Fix/tr 1115 calculate review chars count like common

### DIFF
--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -197,7 +197,8 @@ const inputLimiter = interaction => {
          */
         getCharsCount: () => {
             const value = _getTextContainerValue(interaction) || '';
-            return value.length;
+            // remove NO-BREAK SPACE in empty lines added and all new line symbols
+            return value.replace(/[\r\n]{1}\xA0[\r\n]{1}/gm, '\r').replace(/[\r\n]+/gm, '').length;
         },
 
         /**

--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -196,7 +196,14 @@ const inputLimiter = interaction => {
          * @return {Number} number of characters
          */
         getCharsCount: () => {
-            const value = _getTextContainerValue(interaction) || '';
+            let value = _getTextContainerValue(interaction) || '';
+
+            // convert it to text
+            if (_getFormat(interaction) === 'xhtml') {
+                const div = document.createElement('div');
+                div.innerHTML = value;
+                value = div.textContent || div.innerText || '';
+            }
             // remove NO-BREAK SPACE in empty lines added and all new line symbols
             return value.replace(/[\r\n]{1}\xA0[\r\n]{1}/gm, '\r').replace(/[\r\n]+/gm, '').length;
         },


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-1115

- Calculate character count in the same way in review mode like in common mode (https://github.com/oat-sa/tao-item-runner-qti-fe/blob/fix/TR-1115_calculate-review-chars-count-like-common/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js#L576)

Test:
- Have a test with `ExtendedTextInteraction`
- Fill out a test and add 2 lines to the textarea. Open review mode on results page. Char counter should have the same value like in common mode.
- Fill out the same test, but remove the enter. Open review mode results page. Char counter should have the same value like in common mode.