### PR TITLE
Fix/TR-1098 implement review mode file upload interaction

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
@@ -216,7 +216,7 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
 var _resetGui = function _resetGui(interaction) {
     var $container = containerHelper.get(interaction);
     $container.find('.file-name').text(__('No file selected'));
-    $container.find('.btn-info').text(__('Browse...'));
+    $container.find('.btn-upload').text(__('Browse...'));
 };
 
 /**

--- a/src/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
@@ -63,7 +63,7 @@ var validateFileType = function validateFileType(file, interaction) {
  */
 var getMessageWrongType = function getMessageWrongType(interaction, userSelectedType, messageWrongType) {
     var types = uploadHelper.getExpectedTypes(interaction);
-    var expectedTypeLabels = _.map(_.uniq(types), function(type) {
+    var expectedTypeLabels = _.map(_.uniq(types), function (type) {
         var mime = _.find(uploadHelper.getMimeTypes(), { mime: type });
         if (mime) {
             return mime.label;
@@ -101,7 +101,7 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
         instructionMgr.appendInstruction(
             interaction,
             getMessageWrongType(interaction, filetype, messageWrongType),
-            function() {
+            function () {
                 this.setLevel('error');
                 //clear preview
             }
@@ -120,11 +120,11 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
 
     // Update file processing progress.
 
-    reader.onload = function(e) {
+    reader.onload = function (e) {
         var base64Data, commaPosition, base64Raw, $previewArea;
 
         instructionMgr.removeInstructions(interaction);
-        instructionMgr.appendInstruction(interaction, _readyInstructions, function() {
+        instructionMgr.appendInstruction(interaction, _readyInstructions, function () {
             this.setLevel('success');
         });
         instructionMgr.validateInstructions(interaction);
@@ -146,7 +146,7 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
         });
 
         // we wait for the image to be completely loaded
-        $previewArea.waitForMedia(function() {
+        $previewArea.waitForMedia(function () {
             var $originalImg = $previewArea.find('img'),
                 $largeDisplay = $('.file-upload-preview-popup'),
                 $item = $('.qti-item'),
@@ -171,7 +171,7 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
                 return;
             }
 
-            $previewArea.on('click', function() {
+            $previewArea.on('click', function () {
                 var $modalBody;
 
                 $('.upload-ia-modal-bg').remove();
@@ -181,7 +181,7 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
                 $modalBody.empty().append($originalImg.clone());
 
                 $largeDisplay
-                    .on('opened.modal', function() {
+                    .on('opened.modal', function () {
                         // prevents the rest of the page from scrolling when modal is open
                         $('.tao-item-scope.tao-preview-scope').css('overflow', 'hidden');
 
@@ -191,7 +191,7 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
                             left: (modalWidth - itemWidth - 40) / -2
                         });
                     })
-                    .on('closed.modal', function() {
+                    .on('closed.modal', function () {
                         // make the page scrollable again
                         $('.tao-item-scope.tao-preview-scope').css('overflow', 'auto');
                     })
@@ -213,11 +213,18 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
     reader.readAsDataURL(file);
 };
 
-var _resetGui = function _resetGui(interaction) {
+function resetGui(interaction) {
     var $container = containerHelper.get(interaction);
     $container.find('.file-name').text(__('No file selected'));
-    $container.find('.btn-upload').text(__('Browse...'));
+    $container.find('.btn-info').text(__('Browse...'));
 };
+
+function callResetGui(interaction) {
+    const renderer = interaction.getRenderer();
+    if (_.isFunction(renderer.resetGui)) {
+        renderer.resetGui(interaction);
+    }
+}
 
 /**
  * Init rendering, called after template injected into the DOM
@@ -226,19 +233,19 @@ var _resetGui = function _resetGui(interaction) {
  *
  * @param {object} interaction
  */
-var render = function render(interaction) {
+function render(interaction) {
     var changeListener,
         self = this,
         $input;
     var $container = containerHelper.get(interaction);
-    _resetGui(interaction);
+    callResetGui(interaction);
 
     instructionMgr.appendInstruction(interaction, _initialInstructions);
 
     //init response
     interaction.data('_response', { base: null });
 
-    changeListener = function(e) {
+    changeListener = function (e) {
         var file = e.target.files[0];
 
         // Are you really sure something was selected
@@ -258,7 +265,7 @@ var render = function render(interaction) {
     $input.bind('change', changeListener);
 
     // IE Specific hack, prevents button to slightly move on click
-    $input.bind('mousedown', function(e) {
+    $input.bind('mousedown', function (e) {
         e.preventDefault();
         $(this).blur();
         return false;
@@ -266,7 +273,7 @@ var render = function render(interaction) {
 };
 
 var resetResponse = function resetResponse(interaction) {
-    _resetGui(interaction);
+    callResetGui(interaction);
 };
 
 /**
@@ -384,5 +391,5 @@ export default {
     getData: getCustomData,
 
     // Exposed private methods for qtiCreator
-    resetGui: _resetGui
+    resetGui: resetGui
 };

--- a/src/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/UploadInteraction.js
@@ -213,6 +213,11 @@ var _handleSelectedFiles = function _handleSelectedFiles(interaction, file, mess
     reader.readAsDataURL(file);
 };
 
+/**
+ * Resets the GUI state to the default display.
+ *
+ * @param {Object} interaction
+ */
 function resetGui(interaction) {
     var $container = containerHelper.get(interaction);
     $container.find('.file-name').text(__('No file selected'));

--- a/src/qtiCommonRenderer/tpl/interactions/uploadInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/uploadInteraction.tpl
@@ -3,7 +3,7 @@
 	<div class="instruction-container"></div>
     <div class="file-upload fixed-grid-row lft">
         <div class="progressbar"></div>
-        <span class="btn-info small col-4"></span>
+        <span class="btn-info btn-upload small col-4"></span>
         <span class="file-name placeholder col-8 truncate"></span>
         <input type="file" {{#if accept}}accept="{{accept}}"{{/if}}/>
     </div>

--- a/src/qtiCommonRenderer/tpl/interactions/uploadInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/uploadInteraction.tpl
@@ -3,8 +3,8 @@
 	<div class="instruction-container"></div>
     <div class="file-upload fixed-grid-row lft">
         <div class="progressbar"></div>
-        <span class="btn-info btn-upload small col-4"></span>
-        <span class="file-name placeholder col-8 truncate"></span>
+        <span class="btn-info small col-4">{{__ 'Browse...'}}</span>
+        <span class="file-name placeholder col-8 truncate">{{__ "No file selected"}}</span>
         <input type="file" {{#if accept}}accept="{{accept}}"{{/if}}/>
     </div>
     <div class="file-upload-preview lft visible-file-upload-preview runtime-visible-file-upload-preview">

--- a/src/reviewRenderer/renderers/interactions/UploadInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/UploadInteraction.js
@@ -24,6 +24,7 @@ import template from 'taoQtiItem/reviewRenderer/tpl/interactions/uploadInteracti
 import uploadInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/UploadInteraction';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import __ from 'i18n';
+import 'ui/previewer';
 /**
  * Set the response to the rendered interaction.
  *
@@ -41,6 +42,7 @@ var setResponse = function setResponse(interaction, response) {
         downloadUrl,
         mime,
         downloadLink = document.createElement("a"),
+        $previewArea,
         $container = containerHelper.get(interaction);
 
     if (response.base !== null) {
@@ -63,6 +65,12 @@ var setResponse = function setResponse(interaction, response) {
                 downloadLink.click();
             });
 
+        $previewArea = $container.find('.file-upload-preview');
+        $previewArea.previewer({
+            url: downloadUrl,
+            name: filename,
+            mime: mime
+        });
     }
     interaction.data('_response', response);
 };

--- a/src/reviewRenderer/renderers/interactions/UploadInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/UploadInteraction.js
@@ -80,6 +80,8 @@ function setResponse(interaction, response) {
 
 function render(interaction) {
     callResetGui(interaction);
+    //init response
+    interaction.data('_response', { base: null });
 };
 
 function callResetGui(interaction) {

--- a/src/reviewRenderer/renderers/interactions/UploadInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/UploadInteraction.js
@@ -22,5 +22,70 @@
  */
 import template from 'taoQtiItem/reviewRenderer/tpl/interactions/uploadInteraction';
 import uploadInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/UploadInteraction';
+import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
+import __ from 'i18n';
+/**
+ * Set the response to the rendered interaction.
+ *
+ * The response format follows the IMS PCI recommendation :
+ * http://www.imsglobal.org/assessment/pciv1p0cf/imsPCIv1p0cf.html#_Toc353965343
+ *
+ * Available base types are defined in the QTI v2.1 information model:
+ * http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10321
+ *
+ * @param {object} interaction
+ * @param {object} response
+ */
+var setResponse = function setResponse(interaction, response) {
+    var filename,
+        downloadUrl,
+        mime,
+        downloadLink = document.createElement("a"),
+        $container = containerHelper.get(interaction);
 
-export default Object.assign({}, uploadInteraction, {template});
+    if (response.base !== null) {
+        filename =
+            typeof response.base.file.name !== 'undefined' ? response.base.file.name : 'previously-uploaded-file';
+        mime = response.base.file.mime;
+        downloadUrl = typeof response.base.file.data !== 'undefined' ? 'data:' + mime + ';base64,' + response.base.file.data : '';
+
+        $container
+            .find('.file-name')
+            .empty()
+            .text(filename);
+
+        $container
+            .find('.btn-download')
+            .click(function (e) {
+                e.preventDefault();
+                downloadLink.href = downloadUrl;
+                downloadLink.download = filename;
+                downloadLink.click();
+            });
+
+    }
+    interaction.data('_response', response);
+};
+
+/**
+ * Init rendering, called after template injected into the DOM
+ * All options are listed in the QTI v2.1 information model:
+ * http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10321
+ *
+ * @param {object} interaction
+ */
+var render = function render(interaction) {
+    _resetGui(interaction);
+};
+
+var _resetGui = function _resetGui(interaction) {
+    var $container = containerHelper.get(interaction);
+    $container.find('.btn-download').append(__('Download'));
+};
+
+export default Object.assign({}, uploadInteraction, {
+    template,
+    setResponse,
+    render,
+    resetGui: _resetGui
+});

--- a/src/reviewRenderer/tpl/interactions/uploadInteraction.tpl
+++ b/src/reviewRenderer/tpl/interactions/uploadInteraction.tpl
@@ -1,17 +1,7 @@
 <div class="qti-interaction qti-blockInteraction qti-uploadInteraction" data-serial="{{serial}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
 	{{#if prompt}}{{{prompt}}}{{/if}}
-	<div class="instruction-container"></div>
     <div class="file-upload fixed-grid-row lft">
-        <div class="progressbar"></div>
-        <span class="btn-info small col-4"></span>
         <span class="file-name placeholder col-8 truncate"></span>
-        <input disabled type="file" {{#if accept}}accept="{{accept}}"{{/if}}/>
-    </div>
-    <div class="file-upload-preview lft visible-file-upload-preview runtime-visible-file-upload-preview">
-        <p class="nopreview">{{__ 'No preview available'}}</p>
-    </div>
-    <div class="file-upload-preview-popup modal">
-        <div class="modal-body">
-        </div>
+        <a class="btn-download btn-info small"><span class="icon-download"></span></a>
     </div>
 </div>

--- a/src/reviewRenderer/tpl/interactions/uploadInteraction.tpl
+++ b/src/reviewRenderer/tpl/interactions/uploadInteraction.tpl
@@ -2,9 +2,9 @@
 	{{#if prompt}}{{{prompt}}}{{/if}}
     <div class="file-upload fixed-grid-row lft">
         <span class="file-name placeholder col-8 truncate"></span>
-        <a class="btn-download btn-info small"><span class="icon-download"></span></a>
+        <button type="button" data-control="download" class="btn-info small"><span class="icon-download"></span> {{__ "Download"}}</button>
     </div>
     <div class="file-upload-preview lft visible-file-upload-preview runtime-visible-file-upload-preview">
-        <p class="nopreview">{{__ 'No preview available'}}</p>
+        <p class="nopreview">{{__ 'No uploaded file'}}</p>
     </div>
 </div>

--- a/src/reviewRenderer/tpl/interactions/uploadInteraction.tpl
+++ b/src/reviewRenderer/tpl/interactions/uploadInteraction.tpl
@@ -4,4 +4,7 @@
         <span class="file-name placeholder col-8 truncate"></span>
         <a class="btn-download btn-info small"><span class="icon-download"></span></a>
     </div>
+    <div class="file-upload-preview lft visible-file-upload-preview runtime-visible-file-upload-preview">
+        <p class="nopreview">{{__ 'No preview available'}}</p>
+    </div>
 </div>


### PR DESCRIPTION
Related to [https://oat-sa.atlassian.net/browse/TR-1098](https://oat-sa.atlassian.net/browse/TR-1098)

- Remove the option of upload a file on Review mode
- Add option of download the uploaded file
- Add a preview of the uploaded file

Test:
- Upload a file on a file upload item test
- Complete the test and go to Results tab and check on the Review view
- You should can download the file and see a preview of it