### PR TITLE
Hotfix/TR-1131/delay the size adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/helpers/sizeAdapter.js
+++ b/src/qtiCommonRenderer/helpers/sizeAdapter.js
@@ -55,7 +55,7 @@ export default {
                     if (e.target.rel === 'stylesheet') {
                         // give time to slower computers to apply loaded styles
                         setTimeout(() => {
-                            //adaptSize.height($elements);
+                            adaptSize.height($elements);
                         }, 0);
                     }
                 },

--- a/src/qtiCommonRenderer/helpers/sizeAdapter.js
+++ b/src/qtiCommonRenderer/helpers/sizeAdapter.js
@@ -45,13 +45,17 @@ export default {
 
         $container.waitForMedia(function () {
             adaptSize.height($elements);
+            // delay a resize as some browsers are not emitting the load event on the LINK elements (Chrome)
+            setTimeout(() => {
+                adaptSize.height($elements);
+            }, 300);
             document.addEventListener(
                 'load',
                 function (e) {
                     if (e.target.rel === 'stylesheet') {
                         // give time to slower computers to apply loaded styles
                         setTimeout(() => {
-                            adaptSize.height($elements);
+                            //adaptSize.height($elements);
                         }, 0);
                     }
                 },


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1131

Delay a call to the sizeAdapter as some browsers are not emitting the load event on the LINK elements (Chrome).
The existing behaviour is kept, an additional delayed call is added to take care of this.