### PR TITLE
Fix/TR-1131/Update the size of the choice interaction once the theme has been applied to the item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,9 +175,8 @@
             "dev": true
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.22.14",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.14.tgz",
-            "integrity": "sha512-AFfaJJuEVs/DBMa0dbYIG9JpnvTIeJkQ6+eQtnKEnVYlGiaoq5fQbbNeOH+nsm8NiKEeqNk6NpcNQGLzoNvWEw==",
+            "version": "github:oat-sa/tao-core-ui-fe#189ad034f3dfec84884fa89a56cd60f24d32a74c",
+            "from": "github:oat-sa/tao-core-ui-fe#feature/TR-1131/emit-theme-applied-event",
             "dev": true
         },
         "@oat-sa/tao-item-runner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,8 +175,9 @@
             "dev": true
         },
         "@oat-sa/tao-core-ui": {
-            "version": "github:oat-sa/tao-core-ui-fe#189ad034f3dfec84884fa89a56cd60f24d32a74c",
-            "from": "github:oat-sa/tao-core-ui-fe#feature/TR-1131/emit-theme-applied-event",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.23.0.tgz",
+            "integrity": "sha512-h8QinckVenKnZCjrZydXCucKwnhDYL5f5ln58HsoWqW2qNkL6RWt1QHwtqGA8XS4cFS4sPu0FuO4rzoUDOkHbA==",
             "dev": true
         },
         "@oat-sa/tao-item-runner": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@oat-sa/tao-core-libs": "^0.4.4",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "^0.1.0",
-        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TR-1131/emit-theme-applied-event",
+        "@oat-sa/tao-core-ui": "1.23.0",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-qunit-testrunner": "^1.0.3",
         "async": "^0.2.10",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@oat-sa/tao-core-libs": "^0.4.4",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "^0.1.0",
-        "@oat-sa/tao-core-ui": "^1.22.14",
+        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TR-1131/emit-theme-applied-event",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-qunit-testrunner": "^1.0.3",
         "async": "^0.2.10",

--- a/src/qtiCommonRenderer/helpers/sizeAdapter.js
+++ b/src/qtiCommonRenderer/helpers/sizeAdapter.js
@@ -26,9 +26,9 @@ export default {
      *
      * @param {jQueryElement|widget} target
      */
-    adaptSize: function (target) {
-        var $elements;
-        var $container;
+    adaptSize(target) {
+        let $elements;
+        let $container;
 
         switch (true) {
             // widget
@@ -47,12 +47,9 @@ export default {
             adaptSize.height($elements);
             document.addEventListener(
                 'load',
-                function (e) {
-                    if (e.target.rel === 'stylesheet') {
-                        // give time to slower computers to apply loaded styles
-                        setTimeout(() => {
-                            adaptSize.height($elements);
-                        }, 0);
+                e => {
+                    if (e.target && e.target.rel === 'stylesheet') {
+                        adaptSize.height($elements);
                     }
                 },
                 true

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -29,6 +29,7 @@ import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import instructionMgr from 'taoQtiItem/qtiCommonRenderer/helpers/instructions/instructionManager';
 import pciResponse from 'taoQtiItem/qtiCommonRenderer/helpers/PciResponse';
 import sizeAdapter from 'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter';
+import adaptSize from 'util/adaptSize';
 
 var KEY_CODE_SPACE = 32;
 var KEY_CODE_ENTER = 13;
@@ -292,7 +293,10 @@ var render = function render(interaction) {
     _setInstructions(interaction);
 
     if (interaction.attr('orientation') === 'horizontal') {
-        sizeAdapter.adaptSize($('.add-option, .result-area .target, .choice-area .qti-choice', $container));
+        const $elements = $('.add-option, .result-area .target, .choice-area .qti-choice', $container);
+        sizeAdapter.adaptSize($elements);
+
+        $(document).on('themeapplied.choiceInteraction', () => adaptSize.height($elements));
     }
 };
 
@@ -390,7 +394,9 @@ var destroy = function destroy(interaction) {
 
     //remove event
     $container.off('.commonRenderer');
-    $(document).off('.commonRenderer');
+    $(document)
+        .off('.commonRenderer')
+        .off('.choiceInteraction');
 
     //remove instructions
     instructionMgr.removeInstructions(interaction);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1131

Requires: 
 - [x] https://github.com/oat-sa/tao-core-ui-fe/pull/284
 - [x] once the companion PR has been merged, the package.json and package-lock.json files must updated with the proper version

Apply a resize of the choice interaction once the item them has been applied.

The issue reproduces only in Chrome as the load event is not emitted for the LINK elements, so that we need to rely on a different approach to adapt the size once the theme is applied.