### PR TITLE
fix: MathMl render error

### DIFF
--- a/src/qtiCommonRenderer/renderers/Math.js
+++ b/src/qtiCommonRenderer/renderers/Math.js
@@ -48,7 +48,6 @@ export default {
                 }
                 //defer execution fix some rendering issue in chrome
                 if ($item.length) {
-                    $item.data('mathInitialized', true);
                     MathJax.Hub.Queue(['Typeset', MathJax.Hub, $item[0]]);
                     MathJax.Hub.Queue(resolve);
                 } else {

--- a/src/qtiCommonRenderer/renderers/Math.js
+++ b/src/qtiCommonRenderer/renderers/Math.js
@@ -39,7 +39,7 @@ export default {
     template: tpl,
     getContainer: containerHelper.get,
     render: function render(math) {
-        return new Promise(function(resolve) {
+        return new Promise(function (resolve) {
             var $item = containerHelper.get(math).closest('.qti-item');
             if (typeof MathJax !== 'undefined' && MathJax) {
                 //MathJax needs to be exported globally to integrate with tools like TTS, it's weird...
@@ -47,7 +47,7 @@ export default {
                     window.MathJax = MathJax;
                 }
                 //defer execution fix some rendering issue in chrome
-                if ($item.length && !$item.data('mathInitialized')) {
+                if ($item.length) {
                     $item.data('mathInitialized', true);
                     MathJax.Hub.Queue(['Typeset', MathJax.Hub, $item[0]]);
                     MathJax.Hub.Queue(resolve);


### PR DESCRIPTION
**Description**
In every interaction user is able to add Math Expression box and insert an equation in two modes: LaTeX and MathML. 

The issue is that in MathML mode after entering equation (using MathML code), clicking 'Done' or any free space and then typing some text after equation, it's structure becomes broken and remains in this state.

**Note**: Insert this MathML code into MathML text field:
`<mrow>
  <mi>x</mi>
  <mo>=</mo>
  <mfrac>
    <mrow>
      <mrow>
        <mo>-</mo>
        <mi>b</mi>
      </mrow>
      <mo>&PlusMinus;</mo>
      <msqrt>
        <mrow>
          <msup>
            <mi>b</mi>
            <mn>2</mn>
          </msup>
          <mo>-</mo>
          <mrow>
            <mn>4</mn>
            <mo>&InvisibleTimes;</mo>
            <mi>a</mi>
            <mo>&InvisibleTimes;</mo>
            <mi>c</mi>
          </mrow>
        </mrow>
      </msqrt>
    </mrow>
    <mrow>
      <mn>2</mn>
      <mo>&InvisibleTimes;</mo>
      <mi>a</mi>
    </mrow>
  </mfrac>
</mrow>
`
**Steps to reproduce:**

Create an item containing any interaction with the text field (f. e. Choice Int.).

Insert a Math Expression box by clicking 'π' icon.

Choose MathML in Editing Mode dropdown menu.

Insert MathML code from **Note** into MathML text field.

Click 'Done' or any free space.

Type some text after the equation.
**Actual result**: Equation syntax and structure is ruined and remains in this state.
**Expected result**: Equation remains unchanged.

**Environment**
Reproduce : https://deckard.lab.taocloud.org
Test :http://tao-test-alshoja.playground.kitchen.it.taocloud.org:46031
Browsers: Google Chrome, MS Edge, IE 11
OS: Windows 10
