### PR TITLE
Feature/aut 22/add ckeditor to inline choice

### DIFF
--- a/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
+++ b/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
@@ -27,5 +27,19 @@ import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 export default {
     qtiClass: 'inlineChoice',
     getContainer: containerHelper.get,
-    template: tpl
+    template: tpl,
+    getData: function getData(choice, data) {
+        const widget = choice.metaData.widget;
+        let container = choice.getBody();
+        if (widget) {
+            container = widget.element.getBody();
+        }
+        data.body = container.render(
+            _.clone({ interaction: choice }, true),
+            null,
+            container.qtiClass + '.' + choice.qtiClass,
+            choice.getRenderer()
+        );
+        return data;
+    }
 };

--- a/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
+++ b/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
@@ -27,19 +27,5 @@ import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 export default {
     qtiClass: 'inlineChoice',
     getContainer: containerHelper.get,
-    template: tpl,
-    getData: function getData(choice, data) {
-        const widget = choice.metaData.widget;
-        let container = choice.getBody();
-        if (widget) {
-            container = widget.element.getBody();
-        }
-        data.body = container.render(
-            _.clone({ interaction: choice }, true),
-            null,
-            container.qtiClass + '.' + choice.qtiClass,
-            choice.getRenderer()
-        );
-        return data;
-    }
+    template: tpl
 };

--- a/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
+++ b/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
@@ -30,7 +30,6 @@ export default {
     getContainer: containerHelper.get,
     template: tpl,
     getData: function getData(choice, data) {
-        data.body = _.unescape(data.body);
         return data;
     }
 };

--- a/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
+++ b/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
@@ -28,8 +28,5 @@ import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 export default {
     qtiClass: 'inlineChoice',
     getContainer: containerHelper.get,
-    template: tpl,
-    getData: function getData(choice, data) {
-        return data;
-    }
+    template: tpl
 };

--- a/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
+++ b/src/qtiCommonRenderer/renderers/choices/InlineChoice.js
@@ -21,7 +21,6 @@
  * @author Sam Sipasseuth <sam@taotesting.com>
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-import _ from 'lodash';
 import tpl from 'taoQtiItem/qtiCommonRenderer/tpl/choices/inlineChoice';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 

--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -42,6 +42,8 @@ const _defaultOptions = {
     placeholderText: __('select a choice')
 };
 
+const optionSelector = 'div[role="option"]';
+
 /**
  * Init rendering, called after template injected into the DOM
  * All options are listed in the QTI v2.1 information model:
@@ -58,16 +60,16 @@ const render = function (interaction, options) {
     _.extend(opts, options);
 
     if (opts.allowEmpty && !required) {
-        $container.find('div[data-identifier=' + _emptyValue + ']').text('--- ' + __('leave empty') + ' ---');
+        $container.find(`div[data-identifier=${_emptyValue}]`).text('--- ' + __('leave empty') + ' ---');
     } else {
-        $container.find('div[data-identifier=' + _emptyValue + ']').remove();
+        $container.find(`div[data-identifier=${_emptyValue}]`).remove();
     }
 
     $container.select2({
         data: $container
-            .find('div[role="option"]')
+            .find(optionSelector)
             .map((i, opt) => ({
-                id: i,
+                id: $(opt).data('identifier'),
                 markup: opt.outerHTML
             }))
             .get(),
@@ -77,7 +79,7 @@ const render = function (interaction, options) {
         formatSelection: function (data) {
             return data.markup;
         },
-        width: '100%',
+        width: 'fit-content',
         placeholder: opts.placeholderText,
         minimumResultsForSearch: -1,
         dropdownCssClass: 'qti-inlineChoiceInteraction-dropdown'
@@ -102,10 +104,10 @@ const render = function (interaction, options) {
                 const $selectedIndex = $(e.currentTarget)[0].options.selectedIndex
                     ? $(e.currentTarget)[0].options.selectedIndex
                     : null;
-                $container.find('div[role="option"]').one('click', function (e) {
+                $container.find(optionSelector).one('click', function (e) {
                     e.stopPropagation();
                 });
-                $container.find('div[role="option"]').eq($selectedIndex).trigger('click');
+                $container.find(optionSelector).eq($selectedIndex).trigger('click');
             }
 
             if (required && $container.val() !== '') {
@@ -212,7 +214,7 @@ const setState = function setState(interaction, state) {
             //just in case the dropdown is opened
             $container.select2('disable').select2('close');
 
-            $('option[data-identifier]', $container)
+            $(optionSelector, $container)
                 .sort(function (a, b) {
                     const aIndex = _.indexOf(state.order, $(a).data('identifier'));
                     const bIndex = _.indexOf(state.order, $(b).data('identifier'));
@@ -252,7 +254,7 @@ const getState = function getState(interaction) {
         $container = containerHelper.get(interaction);
 
         state.order = [];
-        $('option[data-identifier]', $container).each(function () {
+        $(optionSelector, $container).each(function () {
             state.order.push($(this).data('identifier'));
         });
     }

--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -35,9 +35,9 @@ import 'select2';
  * The value of the "empty" option
  * @type String
  */
-var _emptyValue = 'empty';
+const _emptyValue = 'empty';
 
-var _defaultOptions = {
+const _defaultOptions = {
     allowEmpty: true,
     placeholderText: __('select a choice')
 };
@@ -49,28 +49,41 @@ var _defaultOptions = {
  *
  * @param {object} interaction
  */
-var render = function(interaction, options) {
-    var opts = _.clone(_defaultOptions);
-    var required = !!interaction.attr('required');
-    var choiceTooltip;
-    var $container = containerHelper.get(interaction);
+const render = function (interaction, options) {
+    const opts = _.clone(_defaultOptions);
+    const required = !!interaction.attr('required');
+    let choiceTooltip;
+    const $container = containerHelper.get(interaction);
 
     _.extend(opts, options);
 
     if (opts.allowEmpty && !required) {
-        $container.find('option[value=' + _emptyValue + ']').text('--- ' + __('leave empty') + ' ---');
+        $container.find('div[data-identifier=' + _emptyValue + ']').text('--- ' + __('leave empty') + ' ---');
     } else {
-        $container.find('option[value=' + _emptyValue + ']').remove();
+        $container.find('div[data-identifier=' + _emptyValue + ']').remove();
     }
 
     $container.select2({
-        width: 'element',
+        data: $container
+            .find('div[role="option"]')
+            .map((i, opt) => ({
+                id: i,
+                markup: opt.outerHTML
+            }))
+            .get(),
+        formatResult: function (result) {
+            return result.markup;
+        },
+        formatSelection: function (data) {
+            return data.markup;
+        },
+        width: '100%',
         placeholder: opts.placeholderText,
         minimumResultsForSearch: -1,
         dropdownCssClass: 'qti-inlineChoiceInteraction-dropdown'
     });
 
-    var $el = $container.select2('container');
+    const $el = $container.select2('container');
 
     if (required) {
         //set up the tooltip plugin for the input
@@ -82,24 +95,17 @@ var render = function(interaction, options) {
     }
 
     $container
-        .on('change', function(e) {
+        .on('change', function (e) {
             //if tts component is loaded and click-to-speak function is activated - we must fix the situation when select2 prevents tts from working
             //for this a "one-moment" handler of option click is added and removed after event fired
-            if (
-                $(e.currentTarget)
-                    .closest('.qti-item')
-                    .hasClass('prevent-click-handler')
-            ) {
-                var $selectedIndex = $(e.currentTarget)[0].options.selectedIndex
+            if ($(e.currentTarget).closest('.qti-item').hasClass('prevent-click-handler')) {
+                const $selectedIndex = $(e.currentTarget)[0].options.selectedIndex
                     ? $(e.currentTarget)[0].options.selectedIndex
                     : null;
-                $container.find('option').one('click', function(e) {
+                $container.find('div[role="option"]').one('click', function (e) {
                     e.stopPropagation();
                 });
-                $container
-                    .find('option')
-                    .eq($selectedIndex)
-                    .trigger('click');
+                $container.find('div[role="option"]').eq($selectedIndex).trigger('click');
             }
 
             if (required && $container.val() !== '') {
@@ -108,27 +114,24 @@ var render = function(interaction, options) {
 
             containerHelper.triggerResponseChangeEvent(interaction);
         })
-        .on('select2-open', function() {
+        .on('select2-open', function () {
             if (required) {
                 choiceTooltip.hide();
             }
         })
-        .on('select2-close', function() {
+        .on('select2-close', function () {
             if (required && $container.val() === '') {
                 choiceTooltip.show();
             }
         });
 };
 
-var resetResponse = function(interaction) {
+const resetResponse = function (interaction) {
     _setVal(interaction, _emptyValue);
 };
 
-var _setVal = function(interaction, choiceIdentifier) {
-    containerHelper
-        .get(interaction)
-        .val(choiceIdentifier)
-        .select2('val', choiceIdentifier);
+const _setVal = function (interaction, choiceIdentifier) {
+    containerHelper.get(interaction).val(choiceIdentifier).select2('val', choiceIdentifier);
 };
 
 /**
@@ -143,12 +146,12 @@ var _setVal = function(interaction, choiceIdentifier) {
  * @param {object} interaction
  * @param {object} response
  */
-var setResponse = function(interaction, response) {
+const setResponse = function (interaction, response) {
     _setVal(interaction, pciResponse.unserialize(response, interaction)[0]);
 };
 
-var _getRawResponse = function(interaction) {
-    var value = containerHelper.get(interaction).val();
+const _getRawResponse = function (interaction) {
+    const value = containerHelper.get(interaction).val();
     return value && value !== _emptyValue ? [value] : [];
 };
 
@@ -164,7 +167,7 @@ var _getRawResponse = function(interaction) {
  * @param {object} interaction
  * @returns {object}
  */
-var getResponse = function(interaction) {
+const getResponse = function (interaction) {
     return pciResponse.serialize(_getRawResponse(interaction), interaction);
 };
 
@@ -172,8 +175,8 @@ var getResponse = function(interaction) {
  * Clean interaction destroy
  * @param {Object} interaction
  */
-var destroy = function(interaction) {
-    var $container = containerHelper.get(interaction);
+const destroy = function (interaction) {
+    const $container = containerHelper.get(interaction);
 
     //remove event
     $(document).off('.commonRenderer');
@@ -193,8 +196,8 @@ var destroy = function(interaction) {
  * @param {Object} interaction - the interaction instance
  * @param {Object} state - the interaction state
  */
-var setState = function setState(interaction, state) {
-    var $container;
+const setState = function setState(interaction, state) {
+    let $container;
 
     if (_.isObject(state)) {
         if (state.response) {
@@ -210,9 +213,9 @@ var setState = function setState(interaction, state) {
             $container.select2('disable').select2('close');
 
             $('option[data-identifier]', $container)
-                .sort(function(a, b) {
-                    var aIndex = _.indexOf(state.order, $(a).data('identifier'));
-                    var bIndex = _.indexOf(state.order, $(b).data('identifier'));
+                .sort(function (a, b) {
+                    const aIndex = _.indexOf(state.order, $(a).data('identifier'));
+                    const bIndex = _.indexOf(state.order, $(b).data('identifier'));
                     if (aIndex > bIndex) {
                         return 1;
                     }
@@ -235,10 +238,10 @@ var setState = function setState(interaction, state) {
  * @param {Object} interaction - the interaction instance
  * @returns {Object} the interaction current state
  */
-var getState = function getState(interaction) {
-    var $container;
-    var state = {};
-    var response = interaction.getResponse();
+const getState = function getState(interaction) {
+    let $container;
+    const state = {};
+    const response = interaction.getResponse();
 
     if (response) {
         state.response = response;
@@ -249,7 +252,7 @@ var getState = function getState(interaction) {
         $container = containerHelper.get(interaction);
 
         state.order = [];
-        $('option[data-identifier]', $container).each(function() {
+        $('option[data-identifier]', $container).each(function () {
             state.order.push($(this).data('identifier'));
         });
     }
@@ -263,12 +266,12 @@ var getState = function getState(interaction) {
 export default {
     qtiClass: 'inlineChoiceInteraction',
     template: tpl,
-    render: render,
+    render,
     getContainer: containerHelper.get,
-    setResponse: setResponse,
-    getResponse: getResponse,
-    resetResponse: resetResponse,
-    destroy: destroy,
-    setState: setState,
-    getState: getState
+    setResponse,
+    getResponse,
+    resetResponse,
+    destroy,
+    setState,
+    getState
 };

--- a/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
@@ -1,3 +1,20 @@
-<option data-identifier="{{attributes.identifier}}" data-serial="{{serial}}" value="{{attributes.identifier}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
-    {{body}}
-</option>
+<tr class="widget-box widget-inlineChoice qti-choice" data-edit="active" data-serial="{{serial}}">
+    <td class="option">
+        <div class="editable-container">
+            <div class="editable-content" contenteditable="true">{{{body}}}</div>
+        </div>
+    </td>
+    <td class="mini-tlb">
+        <span data-edit="question" class="tlb-button">
+            <span class="icon-{{#if attributes.fixed}}pin{{else}}shuffle{{/if}}" data-role="shuffle-pin" style="{{#if interactionShuffle}}{{else}}display:none;{{/if}}"></span>
+        </span>
+        <label data-edit="map">
+            <input name="correct" type="radio" value="{{serial}}">
+            <span class="icon-radio"></span>
+        </label>
+    </td>
+    <td class="mini-tlb">
+        <span data-edit="question" class="icon-bin" data-role="delete"></span>
+        <input class="score" name="score" data-edit="map" value="{{score}}" data-for="{{serial}}" data-validate="$numeric" data-validate-option="$allowEmpty; $event(type=keyup)"/>
+    </td>
+</tr>

--- a/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
@@ -1,3 +1,3 @@
-<option data-identifier="{{attributes.identifier}}" data-serial="{{serial}}" value="{{attributes.identifier}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
+<div role="option" data-identifier="{{attributes.identifier}}" data-serial="{{serial}}" {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
     {{{body}}}
-</option>
+</div>

--- a/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
@@ -1,3 +1,3 @@
 <option data-identifier="{{attributes.identifier}}" data-serial="{{serial}}" value="{{attributes.identifier}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
-    {{{body}}}
+    {{body}}
 </option>

--- a/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
@@ -1,3 +1,3 @@
 <option data-identifier="{{attributes.identifier}}" data-serial="{{serial}}" value="{{attributes.identifier}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
-    {{body}}
+    {{{body}}}
 </option>

--- a/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/inlineChoice.tpl
@@ -1,20 +1,3 @@
-<tr class="widget-box widget-inlineChoice qti-choice" data-edit="active" data-serial="{{serial}}">
-    <td class="option">
-        <div class="editable-container">
-            <div class="editable-content" contenteditable="true">{{{body}}}</div>
-        </div>
-    </td>
-    <td class="mini-tlb">
-        <span data-edit="question" class="tlb-button">
-            <span class="icon-{{#if attributes.fixed}}pin{{else}}shuffle{{/if}}" data-role="shuffle-pin" style="{{#if interactionShuffle}}{{else}}display:none;{{/if}}"></span>
-        </span>
-        <label data-edit="map">
-            <input name="correct" type="radio" value="{{serial}}">
-            <span class="icon-radio"></span>
-        </label>
-    </td>
-    <td class="mini-tlb">
-        <span data-edit="question" class="icon-bin" data-role="delete"></span>
-        <input class="score" name="score" data-edit="map" value="{{score}}" data-for="{{serial}}" data-validate="$numeric" data-validate-option="$allowEmpty; $event(type=keyup)"/>
-    </td>
-</tr>
+<option data-identifier="{{attributes.identifier}}" data-serial="{{serial}}" value="{{attributes.identifier}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
+    {{body}}
+</option>

--- a/src/qtiCommonRenderer/tpl/interactions/inlineChoiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/inlineChoiceInteraction.tpl
@@ -1,10 +1,9 @@
-<select {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-inlineInteraction qti-inlineChoiceInteraction{{#if attributes.class}} {{attributes.class}}{{/if}}"
+<div role="listbox" {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-inlineInteraction qti-inlineChoiceInteraction{{#if attributes.class}} {{attributes.class}}{{/if}}"
         data-serial="{{serial}}"
         data-qti-class="inlineChoiceInteraction"
         data-has-search="false"
         {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
 >
-    <option></option>                {{!-- select2 needs an empty option for the placeholder --}}
-    <option value="empty"></option>
+    <div role="option" data-identifier="empty"></div>
     {{#choices}}{{{.}}}{{/choices}}
-</select>
+</div>

--- a/src/qtiItem/core/choices/InlineChoice.js
+++ b/src/qtiItem/core/choices/InlineChoice.js
@@ -1,6 +1,6 @@
-import QtiTextVariableChoice from 'taoQtiItem/qtiItem/core/choices/TextVariableChoice';
+import QtiContainerChoice from 'taoQtiItem/qtiItem/core/choices/ContainerChoice';
 import Container from 'taoQtiItem/qtiItem/mixin/ContainerInline';
-var QtiInlineChoice = QtiTextVariableChoice.extend({
+var QtiInlineChoice = QtiContainerChoice.extend({
     qtiClass: 'inlineChoice'
 });
 Container.augment(QtiInlineChoice);

--- a/src/qtiItem/core/choices/InlineChoice.js
+++ b/src/qtiItem/core/choices/InlineChoice.js
@@ -1,7 +1,5 @@
 import QtiContainerChoice from 'taoQtiItem/qtiItem/core/choices/ContainerChoice';
-import Container from 'taoQtiItem/qtiItem/mixin/ContainerInline';
 var QtiInlineChoice = QtiContainerChoice.extend({
     qtiClass: 'inlineChoice'
 });
-Container.augment(QtiInlineChoice);
 export default QtiInlineChoice;

--- a/src/qtiItem/core/choices/InlineChoice.js
+++ b/src/qtiItem/core/choices/InlineChoice.js
@@ -1,5 +1,7 @@
 import QtiTextVariableChoice from 'taoQtiItem/qtiItem/core/choices/TextVariableChoice';
+import Container from 'taoQtiItem/qtiItem/mixin/ContainerInline';
 var QtiInlineChoice = QtiTextVariableChoice.extend({
     qtiClass: 'inlineChoice'
 });
+Container.augment(QtiInlineChoice);
 export default QtiInlineChoice;

--- a/test/qtiCommonRenderer/interactions/inlineChoice/test.js
+++ b/test/qtiCommonRenderer/interactions/inlineChoice/test.js
@@ -20,7 +20,7 @@ define([
 
     QUnit.test('renders correclty', function(assert) {
         var ready = assert.async();
-        assert.expect(17);
+        assert.expect(14);
 
         var $container = $('#' + fixtureContainerId);
 
@@ -42,24 +42,19 @@ define([
                     'the container contains a the body element .qti-itemBody'
                 );
                 assert.equal(
-                    $container.find('select.qti-interaction').length,
+                    $container.find('div[role="listbox"].qti-interaction').length,
                     1,
                     'the container contains an interaction .qti-interaction'
                 );
                 assert.equal(
-                    $container.find('select.qti-interaction.qti-inlineChoiceInteraction').length,
+                    $container.find('div[role="listbox"].qti-interaction.qti-inlineChoiceInteraction').length,
                     1,
                     'the container contains a choice interaction .qti-inlineChoiceInteraction'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option').length,
-                    5,
-                    'the interaction has 5 options'
-                );
-                assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option[data-identifier]').length,
-                    3,
-                    'the interaction has 3 choices'
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    4,
+                    'the interaction has 4 choices ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length
                 );
 
                 //Check select2
@@ -77,34 +72,24 @@ define([
                 );
 
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option:nth-child(1)').val(),
-                    '',
-                    'the 1st choice has no value'
-                );
-                assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option:nth-child(1)').text(),
-                    '',
-                    'the 1st choice is empty'
-                );
-                assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option:nth-child(2)').val(),
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(1)').data('identifier'),
                     'empty',
-                    'the 2nd choice has a value of "empty"'
+                    'the 1st choice has a value of "empty"'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option:nth-child(3)').data('identifier'),
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(2)').data('identifier'),
                     'G',
-                    'the 3rd choice has the right identifier'
+                    'the 2nd choice has the right identifier ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier')
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option:nth-child(4)').data('identifier'),
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier'),
                     'L',
-                    'the 4th choice has the right identifier'
+                    'the 3rd choice has the right identifier ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier')
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option:nth-child(5)').data('identifier'),
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
                     'Y',
-                    'the 5th choice has the right identifier'
+                    'the 4th choice has the right identifier ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
                 );
 
                 ready();
@@ -124,16 +109,16 @@ define([
 
         runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function() {
-                var $select = $('select.qti-inlineChoiceInteraction', $container);
+                var $select = $('div[role="listbox"].qti-inlineChoiceInteraction', $container);
                 assert.equal(
                     $select.length,
                     1,
                     'the container contains an inlineChoice interaction .qti-inlineChoiceInteraction'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option[data-identifier]').length,
-                    3,
-                    'the interaction has 3 choices'
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    4,
+                    'the interaction has 4 choices ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                 );
 
                 var $select2Container = $('.select2-container', $container);
@@ -147,7 +132,7 @@ define([
                 assert.deepEqual(
                     state.RESPONSE,
                     { response: { base: { identifier: 'L' } } },
-                    'The lancaster response is selected'
+                    'The lancaster response is selected ' + JSON.stringify(state.RESPONSE)
                 );
                 ready();
             })
@@ -166,16 +151,16 @@ define([
 
         runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function() {
-                var $select = $('select.qti-inlineChoiceInteraction', $container);
+                var $select = $('div[role="listbox"].qti-inlineChoiceInteraction', $container);
                 assert.equal(
                     $select.length,
                     1,
                     'the container contains an inlineChoice interaction .qti-inlineChoiceInteraction'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option[data-identifier]').length,
-                    3,
-                    'the interaction has 3 choices'
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    4,
+                    'the interaction has 4 choices ' +  $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                 );
 
                 assert.equal($select.select2('val'), '', 'There is no choice selected');
@@ -183,7 +168,7 @@ define([
                 this.setState({ RESPONSE: { response: { base: { identifier: 'G' } } } });
 
                 _.delay(function() {
-                    assert.equal($select.select2('val'), 'G', 'The G choice is selected');
+                    assert.equal($select.select2('val'), 'G', 'The G choice is selected ' + $select.select2('val'));
 
                     ready();
                 }, 10);
@@ -205,16 +190,17 @@ define([
             .on('render', function() {
                 var self = this;
 
-                var $select = $('select.qti-inlineChoiceInteraction', $container);
+                var $select = $('div[role="listbox"].qti-inlineChoiceInteraction', $container);
                 assert.equal(
                     $select.length,
                     1,
                     'the container contains an inlineChoice interaction .qti-inlineChoiceInteraction'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option[data-identifier]').length,
-                    3,
-                    'the interaction has 3 choices'
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    4,
+                    'the interaction has 4 choices ' +                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+
                 );
 
                 var $select2Container = $('.select2-container', $container);
@@ -255,16 +241,17 @@ define([
             .on('render', function() {
                 var self = this;
 
-                var $select = $('select.qti-inlineChoiceInteraction', $container);
+                var $select = $('div[role="listbox"].qti-inlineChoiceInteraction', $container);
                 assert.equal(
                     $select.length,
                     1,
                     'the container contains an inlineChoice interaction .qti-inlineChoiceInteraction'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option[data-identifier]').length,
-                    3,
-                    'the interaction has 3 choices'
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    4,
+                    'the interaction has 4 choices ' +                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+
                 );
 
                 var $select2Container = $('.select2-container', $container);
@@ -273,14 +260,14 @@ define([
                 $select.select2('val', 'L').trigger('change');
 
                 _.delay(function() {
-                    assert.equal($select.val(), 'L', 'The value is set to Lancaster');
+                    assert.equal($select.val(), 'L', 'The value is set to Lancaster ' + $select.val());
 
                     //Call destroy manually
                     var interaction = self._item.getInteractions()[0];
                     interaction.renderer.resetResponse(interaction);
 
                     _.delay(function() {
-                        assert.equal($select.val(), 'empty', 'The value is now empty');
+                        assert.equal($select.val(), 'empty', 'The value is now empty ' + $select.val());
                         ready();
                     }, 100);
                 }, 100);
@@ -291,7 +278,7 @@ define([
 
     QUnit.test('restores order of shuffled choices', function(assert) {
         var ready = assert.async();
-        assert.expect(10);
+        assert.expect(8);
 
         var $container = $('#' + fixtureContainerId);
 
@@ -306,16 +293,17 @@ define([
             .on('render', function() {
                 var self = this;
 
-                var $select = $('select.qti-inlineChoiceInteraction', $container);
+                var $select = $('div[role="listbox"].qti-inlineChoiceInteraction', $container);
                 assert.equal(
                     $select.length,
                     1,
                     'the container contains an inlineChoice interaction .qti-inlineChoiceInteraction'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option[data-identifier]').length,
-                    3,
-                    'the interaction has 3 choices'
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    4,
+                    'the interaction has 4 choices ' +                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+
                 );
 
                 this.setState({
@@ -327,34 +315,24 @@ define([
 
                 _.delay(function() {
                     assert.equal(
-                        $container.find('select.qti-inlineChoiceInteraction option:nth-child(1)').val(),
-                        '',
-                        'the 1st choice has no value'
-                    );
-                    assert.equal(
-                        $container.find('select.qti-inlineChoiceInteraction option:nth-child(1)').text(),
-                        '',
-                        'the 1st choice is empty'
-                    );
-                    assert.equal(
-                        $container.find('select.qti-inlineChoiceInteraction option:nth-child(2)').val(),
+                        $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(1)').data('identifier'),
                         'empty',
-                        'the 2nd choice has a value of "empty"'
+                        'the 1st choice has a value of "empty" ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(1)').data('identifier'),
                     );
                     assert.equal(
-                        $container.find('select.qti-inlineChoiceInteraction option:nth-child(3)').data('identifier'),
+                        $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(2)').data('identifier'),
                         'Y',
-                        'the 3rd choice has the right identifier'
+                        'the 2nd choice has the right identifier ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(2)').data('identifier'),
                     );
                     assert.equal(
-                        $container.find('select.qti-inlineChoiceInteraction option:nth-child(4)').data('identifier'),
+                        $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier'),
                         'G',
-                        'the 4th choice has the right identifier'
+                        'the 3rd choice has the right identifier ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier'),
                     );
                     assert.equal(
-                        $container.find('select.qti-inlineChoiceInteraction option:nth-child(5)').data('identifier'),
+                        $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
                         'L',
-                        'the 5th choice has the right identifier'
+                        'the 4th choice has the right identifier ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
                     );
 
                     ready();
@@ -377,16 +355,16 @@ define([
 
         runner = qtiItemRunner('qti', inlineChoiceData)
             .on('render', function() {
-                var $select = $('select.qti-inlineChoiceInteraction', $container);
+                var $select = $('div[role="listbox"].qti-inlineChoiceInteraction', $container);
                 assert.equal(
                     $select.length,
                     1,
                     'the container contains an inlineChoice interaction .qti-inlineChoiceInteraction'
                 );
                 assert.equal(
-                    $container.find('select.qti-inlineChoiceInteraction option[data-identifier]').length,
-                    3,
-                    'the interaction has 3 choices'
+                    $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    4,
+                    'the interaction has 4 choices'
                 );
 
                 ready();

--- a/test/qtiCommonRenderer/interactions/inlineChoice/test.js
+++ b/test/qtiCommonRenderer/interactions/inlineChoice/test.js
@@ -54,7 +54,7 @@ define([
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                     4,
-                    'the interaction has 4 choices ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length
+                    'the interaction has 4 choices'
                 );
 
                 //Check select2
@@ -79,17 +79,17 @@ define([
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(2)').data('identifier'),
                     'G',
-                    'the 2nd choice has the right identifier ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier')
+                    'the 2nd choice has the right identifier'
                 );
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier'),
                     'L',
-                    'the 3rd choice has the right identifier ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier')
+                    'the 3rd choice has the right identifier'
                 );
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
                     'Y',
-                    'the 4th choice has the right identifier ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
+                    'the 4th choice has the right identifier',
                 );
 
                 ready();
@@ -118,7 +118,7 @@ define([
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                     4,
-                    'the interaction has 4 choices ' + $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    'the interaction has 4 choices',
                 );
 
                 var $select2Container = $('.select2-container', $container);
@@ -160,7 +160,7 @@ define([
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                     4,
-                    'the interaction has 4 choices ' +  $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
+                    'the interaction has 4 choices',
                 );
 
                 assert.equal($select.select2('val'), '', 'There is no choice selected');
@@ -199,8 +199,7 @@ define([
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                     4,
-                    'the interaction has 4 choices ' +                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
-
+                    'the interaction has 4 choices',
                 );
 
                 var $select2Container = $('.select2-container', $container);
@@ -250,8 +249,7 @@ define([
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                     4,
-                    'the interaction has 4 choices ' +                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
-
+                    'the interaction has 4 choices',
                 );
 
                 var $select2Container = $('.select2-container', $container);
@@ -260,14 +258,14 @@ define([
                 $select.select2('val', 'L').trigger('change');
 
                 _.delay(function() {
-                    assert.equal($select.val(), 'L', 'The value is set to Lancaster ' + $select.val());
+                    assert.equal($select.val(), 'L', 'The value is set to Lancaster');
 
                     //Call destroy manually
                     var interaction = self._item.getInteractions()[0];
                     interaction.renderer.resetResponse(interaction);
 
                     _.delay(function() {
-                        assert.equal($select.val(), 'empty', 'The value is now empty ' + $select.val());
+                        assert.equal($select.val(), 'empty', 'The value is now empty');
                         ready();
                     }, 100);
                 }, 100);
@@ -302,8 +300,7 @@ define([
                 assert.equal(
                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
                     4,
-                    'the interaction has 4 choices ' +                     $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"][data-identifier]').length,
-
+                    'the interaction has 4 choices',
                 );
 
                 this.setState({
@@ -317,22 +314,22 @@ define([
                     assert.equal(
                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(1)').data('identifier'),
                         'empty',
-                        'the 1st choice has a value of "empty" ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(1)').data('identifier'),
+                        'the 1st choice has a value of "empty"',
                     );
                     assert.equal(
                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(2)').data('identifier'),
                         'Y',
-                        'the 2nd choice has the right identifier ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(2)').data('identifier'),
+                        'the 2nd choice has the right identifier',
                     );
                     assert.equal(
                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier'),
                         'G',
-                        'the 3rd choice has the right identifier ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(3)').data('identifier'),
+                        'the 3rd choice has the right identifier',
                     );
                     assert.equal(
                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
                         'L',
-                        'the 4th choice has the right identifier ' +                         $container.find('div[role="listbox"].qti-inlineChoiceInteraction div[role="option"]:nth-child(4)').data('identifier'),
+                        'the 4th choice has the right identifier',
                     );
 
                     ready();

--- a/test/samples/json/richardIII-1.json
+++ b/test/samples/json/richardIII-1.json
@@ -32,7 +32,11 @@
                             "identifier": "G",
                             "fixed": false
                         },
-                        "text": "Gloucester"
+                        "body": {
+                            "body": "Gloucester",
+                            "elements": {},
+                            "serial": "container_containerstatic_60e649a2a5d93459862751"
+                        }
                     },
                     "choice_inlinechoice_547464dbc7ce2756509667": {
                         "identifier": "L",
@@ -42,7 +46,11 @@
                             "identifier": "L",
                             "fixed": false
                         },
-                        "text": "Lancaster"
+                        "body": {
+                            "body": "Lancaster",
+                            "elements": {},
+                            "serial": "container_containerstatic_60e649a2a3c32598966655"
+                        }
                     },
                     "choice_inlinechoice_547464dbc7d18579789437": {
                         "identifier": "Y",
@@ -52,7 +60,11 @@
                             "identifier": "Y",
                             "fixed": false
                         },
-                        "text": "York"
+                        "body": {
+                            "body": "Y",
+                            "elements": {},
+                            "serial": "container_containerstatic_60e64ed68cef3855907756"
+                        }
                     }
                 }
             }
@@ -108,54 +120,63 @@
         "qtiClass": "responseProcessing",
         "attributes": [],
         "processingType": "templateDriven",
-        "responseRules": [{
-            "qtiClass": "responseCondition",
-            "responseIf": {
-                "qtiClass": "responseIf",
-                "expression": {
-                    "qtiClass": "match",
-                    "expressions": [{
-                        "qtiClass": "variable",
-                        "attributes": {
-                            "identifier": "RESPONSE"
+        "responseRules": [
+            {
+                "qtiClass": "responseCondition",
+                "responseIf": {
+                    "qtiClass": "responseIf",
+                    "expression": {
+                        "qtiClass": "match",
+                        "expressions": [
+                            {
+                                "qtiClass": "variable",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            },
+                            {
+                                "qtiClass": "correct",
+                                "attributes": {
+                                    "identifier": "RESPONSE"
+                                }
+                            }
+                        ]
+                    },
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "1"
+                            }
                         }
-                    }, {
-                        "qtiClass": "correct",
-                        "attributes": {
-                            "identifier": "RESPONSE"
-                        }
-                    }]
+                    ]
                 },
-                "responseRules": [{
-                    "qtiClass": "setOutcomeValue",
-                    "attributes": {
-                        "identifier": "SCORE"
-                    },
-                    "expression": {
-                        "qtiClass": "baseValue",
-                        "attributes": {
-                            "baseType": "float"
-                        },
-                        "value": "1"
-                    }
-                }]
-            },
-            "responseElse": {
-                "qtiClass": "responseElse",
-                "responseRules": [{
-                    "qtiClass": "setOutcomeValue",
-                    "attributes": {
-                        "identifier": "SCORE"
-                    },
-                    "expression": {
-                        "qtiClass": "baseValue",
-                        "attributes": {
-                            "baseType": "float"
-                        },
-                        "value": "0"
-                    }
-                }]
+                "responseElse": {
+                    "qtiClass": "responseElse",
+                    "responseRules": [
+                        {
+                            "qtiClass": "setOutcomeValue",
+                            "attributes": {
+                                "identifier": "SCORE"
+                            },
+                            "expression": {
+                                "qtiClass": "baseValue",
+                                "attributes": {
+                                    "baseType": "float"
+                                },
+                                "value": "0"
+                            }
+                        }
+                    ]
+                }
             }
-        }]
+        ]
     }
 }


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/AUT-22

**How to test**
- Create inline choice interaction
- Try to add different markup and math to the choices
- Add new / delete choices
- Save item

**Related PR:** https://github.com/oat-sa/extension-tao-itemqti/pull/1797

Env: http://test-anastasia.playground.kitchen.it.taocloud.org:44451/