### PR TITLE
Backport/tr 1810/disable media player preview under firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.6",
+    "version": "0.10.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "0.10.6",
+    "version": "0.10.7",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -216,7 +216,7 @@ function setResponse(interaction, response) {
             if (interaction.mediaElement) {
                 if (maxPlays !== 0 && maxPlays <= parseInt(timesPlayed, 10)) {
                     interaction.mediaElement.disable();
-                } else {
+                } else if (interaction.mediaElement.is('disabled')) {
                     interaction.mediaElement.enable();
                 }
             }

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -34,15 +34,7 @@ const getContainer = containerHelper.get;
 
 //some default values
 const defaults = {
-    type: 'video/mp4',
-    video: {
-        width: 480,
-        height: 270
-    },
-    audio: {
-        width: 400,
-        height: 30
-    }
+    type: 'video/mp4'
 };
 
 /**
@@ -96,14 +88,16 @@ function render(interaction) {
                     renderTo: $('.media-container', $container)
                 })
                     .on('render', () => {
-                        resize();
+                        // to support old sizes in px
+                        if (media.attr('width') && !/%/.test(media.attr('width'))) {
+                            resize();
 
-                        $(window)
-                            .off('resize.mediaInteraction')
-                            .on('resize.mediaInteraction', resize);
+                            $(window)
+                                .off('resize.mediaInteraction')
+                                .on('resize.mediaInteraction', resize);
 
-                        $item.off('resize.gridEdit').on('resize.gridEdit', resize);
-
+                            $item.off('resize.gridEdit').on('resize.gridEdit', resize);
+                        }
                         /**
                          * @event playerrendered
                          */
@@ -134,14 +128,6 @@ function render(interaction) {
             }
         };
 
-        if (_.size(media.attributes) === 0) {
-            //TODO move to afterCreate
-            media.attr('type', defaults.type);
-            media.attr('width', $container.innerWidth());
-
-            media.attr('height', defaults.video.height);
-            media.attr('data', '');
-        }
 
         //set up the number of times played
         if (!$container.data('timesPlayed')) {

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -208,9 +208,18 @@ function _getRawResponse(interaction) {
 function setResponse(interaction, response) {
     if (response) {
         try {
-            //try to unserialize the pci response
+            const maxPlays = parseInt(interaction.attr('maxPlays'), 10) || 0;
             const responseValues = pciResponse.unserialize(response, interaction);
-            getContainer(interaction).data('timesPlayed', responseValues[0]);
+            const timesPlayed = responseValues[0];
+            getContainer(interaction).data('timesPlayed', timesPlayed);
+
+            if (interaction.mediaElement) {
+                if (maxPlays !== 0 && maxPlays <= parseInt(timesPlayed, 10)) {
+                    interaction.mediaElement.disable();
+                } else {
+                    interaction.mediaElement.enable();
+                }
+            }
         } catch (e) {
             // something went wrong
         }

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -208,11 +208,11 @@ function setResponse(interaction, response) {
         try {
             const maxPlays = parseInt(interaction.attr('maxPlays'), 10) || 0;
             const responseValues = pciResponse.unserialize(response, interaction);
-            const timesPlayed = responseValues[0];
+            const timesPlayed = parseInt(responseValues[0], 10);
             getContainer(interaction).data('timesPlayed', timesPlayed);
 
             if (interaction.mediaElement) {
-                if (maxPlays !== 0 && maxPlays <= parseInt(timesPlayed, 10)) {
+                if (maxPlays !== 0 && maxPlays <= timesPlayed) {
                     interaction.mediaElement.disable();
                 } else if (interaction.mediaElement.is('disabled')) {
                     interaction.mediaElement.enable();

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -149,9 +149,7 @@ function render(interaction) {
         }
 
         //initialize the component
-        $container.on('responseSet', function () {
-            initMediaPlayer();
-        });
+        $container.on('responseSet', initMediaPlayer);
 
         //gives a small chance to the responseSet event before initializing the player
         initMediaPlayer();

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -45,6 +45,7 @@ const defaults = {
  * @param {Object} interaction
  * @fires playerrendered when the player is at least rendered
  * @fires playerready when the player is sucessfully loaded and configured
+ * @returns {Promise}
  */
 function render(interaction) {
     return new Promise(resolve => {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1810

Requires: 
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/347

Backport of #211  to Sprint 134.5.100

Disable the media preview when this is Firefox 87+ and the media interaction targets a WebM content.

**How to test:**
- see the companion PR for more info