### PR TITLE
fix(media-interaction): compund maxscore to 0

### DIFF
--- a/src/qtiItem/core/interactions/MediaInteraction.js
+++ b/src/qtiItem/core/interactions/MediaInteraction.js
@@ -29,6 +29,9 @@ var MediaInteraction = ObjectInteraction.extend({
             };
 
         return this._super(_.merge(defaultData, args.data), args.placeholder, args.subclass, renderer);
+    },
+    getNormalMaximum: function getNormalMaximum() {
+        return 0;
     }
 });
 export default MediaInteraction;


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/AUT-665

**Description:** As agreed on ticket, from now on media interaction will compute for the max score calculation with a value of of `0`, instead of being considered as a invalid interaction for the max score calculation, which was causing to dismiss maxscore value when a media interaction is present.

**How to test**: 
* Create an item with a media interaction plus other item/items with calculated maxscore value.
* Preview item.
* Submit item and verify that `maxscore` value exists.

![aut-665](https://user-images.githubusercontent.com/14041944/137334175-778eb4b0-33a7-4b94-824e-a353f0875025.gif)


