### PR TITLE
fix/TR-3279/fix-ckeditor-ar-clipboard-translate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -510,8 +510,9 @@
             }
         },
         "@oat-sa/tao-core-shared-libs": {
-            "version": "github:oat-sa/tao-core-shared-libs-fe#c250f958a3808316650ad309eab3e91870378177",
-            "from": "github:oat-sa/tao-core-shared-libs-fe#fix/TR-3279/fix-ckeditor-ar-clipboard-translate",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.0.4.tgz",
+            "integrity": "sha512-4o7O/IZAy1U8rPMNIbOQsDwr9lnWEJBr0AsdhTcGT+Nlb09BDKeltu7LVXhnJ0iFm9nG04WqjgjOt1aMmVV+Xg==",
             "dev": true
         },
         "@oat-sa/tao-core-ui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,9 +510,8 @@
             }
         },
         "@oat-sa/tao-core-shared-libs": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.0.3.tgz",
-            "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg==",
+            "version": "github:oat-sa/tao-core-shared-libs-fe#c250f958a3808316650ad309eab3e91870378177",
+            "from": "github:oat-sa/tao-core-shared-libs-fe#fix/TR-3279/fix-ckeditor-ar-clipboard-translate",
             "dev": true
         },
         "@oat-sa/tao-core-ui": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.4.4",
         "@oat-sa/tao-core-sdk": "^1.16.1",
-        "@oat-sa/tao-core-shared-libs": "1.0.3",
+        "@oat-sa/tao-core-shared-libs": "github:oat-sa/tao-core-shared-libs-fe#fix/TR-3279/fix-ckeditor-ar-clipboard-translate",
         "@oat-sa/tao-core-ui": "1.45.0",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-qunit-testrunner": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.4.4",
         "@oat-sa/tao-core-sdk": "^1.16.1",
-        "@oat-sa/tao-core-shared-libs": "github:oat-sa/tao-core-shared-libs-fe#fix/TR-3279/fix-ckeditor-ar-clipboard-translate",
+        "@oat-sa/tao-core-shared-libs": "1.0.4",
         "@oat-sa/tao-core-ui": "1.45.0",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-qunit-testrunner": "^1.0.3",


### PR DESCRIPTION
**Related to:** [TR-3279](https://oat-sa.atlassian.net/browse/TR-3279)

**Description:**
The Arabic text mentions the 'ok' button but as it is translated, the text doesn't match with any button. The 'ok' word must be translated too on the description text.

**Changes:**

- Translate the 'ok' word to match the 'ok' button with the Arabic translation

**Companion:**

- https://github.com/oat-sa/tao-core-shared-libs-fe/pull/11