### PR TITLE
feat: retrieve languages from interaction definition and context

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -20,6 +20,7 @@ import _ from 'lodash';
 import loggerFactory from 'core/logger';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import instanciator from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/instanciator';
+import context from 'context';
 
 const logger = loggerFactory('taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims');
 
@@ -60,7 +61,12 @@ export default function defaultPciRenderer(runtime) {
         },
         createInstance(interaction, context) {
             let pciConstructor = this.getPCIConstructor(interaction);
-            const properties = _.clone(interaction.properties);
+
+            //get interaction xml:lang prop to put it into pci instance config
+            const language = interaction.rootElement && interaction.rootElement.attributes && interaction.rootElement.attributes['xml:lang'];
+            const userLanguage = context.locale;
+
+            const properties = Object.assign(_.clone(interaction.properties), {language, userLanguage});
 
             // save original IMS PCI module first time to be able to reinstanciate later if necessary
             if (!pciConstructor) {

--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -20,7 +20,6 @@ import _ from 'lodash';
 import loggerFactory from 'core/logger';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import instanciator from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/instanciator';
-import context from 'context';
 
 const logger = loggerFactory('taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims');
 

--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -65,9 +65,9 @@ export default function defaultPciRenderer(runtime) {
             const contentLanguage = interaction.attributes && interaction.attributes.language;
             const itemLanguage = interaction.rootElement && interaction.rootElement.attributes && interaction.rootElement.attributes['xml:lang'];
             const language = contentLanguage || itemLanguage;
-            const userLanguage = context.locale;
+            const userLanguage = context && context.locale;
 
-            const properties = Object.assign(_.clone(interaction.properties), {language, userLanguage});
+            const properties = _.assign(_.clone(interaction.properties), {language, userLanguage});
 
             // save original IMS PCI module first time to be able to reinstanciate later if necessary
             if (!pciConstructor) {

--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -63,7 +63,9 @@ export default function defaultPciRenderer(runtime) {
             let pciConstructor = this.getPCIConstructor(interaction);
 
             //get interaction xml:lang prop to put it into pci instance config
-            const language = interaction.rootElement && interaction.rootElement.attributes && interaction.rootElement.attributes['xml:lang'];
+            const contentLanguage = interaction.attributes && interaction.attributes.language;
+            const itemLanguage = interaction.rootElement && interaction.rootElement.attributes && interaction.rootElement.attributes['xml:lang'];
+            const language = contentLanguage || itemLanguage;
             const userLanguage = context.locale;
 
             const properties = Object.assign(_.clone(interaction.properties), {language, userLanguage});

--- a/test/qtiCommonRenderer/interactions/pci/ims/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/ims/test.js
@@ -59,7 +59,6 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
         assert.ok(instancePromise instanceof Promise, 'createInstance returns with a Promise');
 
         instancePromise.then(instance => {
-            console.log(instance.config);
             assert.propEqual(
                 instance,
                 {

--- a/test/qtiCommonRenderer/interactions/pci/ims/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/ims/test.js
@@ -26,15 +26,18 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
         const properties = {
             bar: 'baz'
         };
-        const attributes = {
-            language: 'ru_RU'
+
+        const itemAttributes = {
+            "xml:lang": 'ru_RU'
         };
 
         const interaction = {
             _store: {},
             typeIdentifier,
             properties,
-            attributes,
+            rootElement: {
+                attributes: itemAttributes
+            },
 
             data(key, data) {
                 if (typeof data === 'undefined') {
@@ -45,6 +48,11 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
         };
         const response = { base: null };
         const context = { response, locale: 'ru_RU' };
+
+        const populatedProperties = Object.assign(properties, {
+            language: 'ru_RU',
+            userLanguage: 'ru_RU'
+        });
 
         const instancePromise = ims().createInstance(interaction, context);
 
@@ -58,12 +66,74 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
                     typeIdentifier,
                     dom: 'dom for interaction',
                     config: {
-                        language: 'ru_RU',
-                        userLanguage: 'ru_RU',
                         boundTo: response,
                         ondone: {},
                         onready: {},
-                        properties,
+                        properties: populatedProperties,
+                        status: 'interacting',
+                        templateVariables: {}
+                    }
+                },
+                'passes correct parameters to ims pci'
+            );
+            done();
+        });
+    });
+
+    QUnit.test('content language is preferred over item language', function (assert) {
+        const done = assert.async();
+
+        const typeIdentifier = 'foo';
+        const properties = {
+            bar: 'baz'
+        };
+
+        const itemAttributes = {
+            "xml:lang": 'ru_RU'
+        };
+
+        const interactionAttributes = {
+            language: 'ru_BY'
+        };
+
+        const interaction = {
+            _store: {},
+            typeIdentifier,
+            properties,
+            rootElement: {
+                attributes: itemAttributes
+            },
+            attributes: interactionAttributes,
+
+            data(key, data) {
+                if (typeof data === 'undefined') {
+                    return this._store[key];
+                }
+                this._store[key] = data;
+            }
+        };
+        const response = { base: null };
+        const context = { response, locale: 'ru_RU' };
+
+        const populatedProperties = Object.assign(properties, {
+            language: 'ru_BY',
+            userLanguage: 'ru_RU'
+        });
+
+        const instancePromise = ims().createInstance(interaction, context);
+
+        instancePromise.then(instance => {
+            console.log(instance.config);
+            assert.propEqual(
+                instance,
+                {
+                    typeIdentifier,
+                    dom: 'dom for interaction',
+                    config: {
+                        boundTo: response,
+                        ondone: {},
+                        onready: {},
+                        properties: populatedProperties,
                         status: 'interacting',
                         templateVariables: {}
                     }
@@ -153,7 +223,11 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
                         boundTo: response,
                         ondone: {},
                         onready: {},
-                        properties,
+                        properties: {
+                            "bar": "baz",
+                            language: undefined,
+                            userLanguage: undefined
+                        },
                         status: 'interacting',
                         templateVariables: {}
                     }
@@ -177,7 +251,11 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
                         boundTo: { RESPONSE: newResponse },
                         ondone: {},
                         onready: {},
-                        properties,
+                        properties: {
+                            "bar": "baz",
+                            language: undefined,
+                            userLanguage: undefined
+                        },
                         status: 'interacting',
                         templateVariables: {}
                     }

--- a/test/qtiCommonRenderer/interactions/pci/ims/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/ims/test.js
@@ -26,10 +26,16 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
         const properties = {
             bar: 'baz'
         };
+        const attributes = {
+            language: 'ru_RU'
+        };
+
         const interaction = {
             _store: {},
             typeIdentifier,
             properties,
+            attributes,
+
             data(key, data) {
                 if (typeof data === 'undefined') {
                     return this._store[key];
@@ -38,19 +44,22 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
             }
         };
         const response = { base: null };
-        const context = { response };
+        const context = { response, locale: 'ru_RU' };
 
         const instancePromise = ims().createInstance(interaction, context);
 
         assert.ok(instancePromise instanceof Promise, 'createInstance returns with a Promise');
 
         instancePromise.then(instance => {
+            console.log(instance.config);
             assert.propEqual(
                 instance,
                 {
                     typeIdentifier,
                     dom: 'dom for interaction',
                     config: {
+                        language: 'ru_RU',
+                        userLanguage: 'ru_RU',
                         boundTo: response,
                         ondone: {},
                         onready: {},


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/TR-3246

### Description 
PCI [configuration](https://www.imsglobal.org/spec/qti/v3p0/impl#h.1mc9puik2ft6) object is passed on pci instance creation. This PR brings population  of the config with language props.

### How to test

Using DevTools check pciConstructor.getInstance is called with configured language in config object 
