### PR TITLE
Fix/tr 3246/locale from shared context

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -21,6 +21,8 @@ import loggerFactory from 'core/logger';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import instanciator from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/instanciator';
 
+import sharedContext from 'context';
+
 const logger = loggerFactory('taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims');
 
 const pciDoneCallback = pci => {
@@ -65,7 +67,7 @@ export default function defaultPciRenderer(runtime) {
             const contentLanguage = interaction.attributes && interaction.attributes.language;
             const itemLanguage = interaction.rootElement && interaction.rootElement.attributes && interaction.rootElement.attributes['xml:lang'];
             const language = contentLanguage || itemLanguage;
-            const userLanguage = context && context.locale;
+            const userLanguage = sharedContext && sharedContext.locale;
 
             const properties = _.assign(_.clone(interaction.properties), {language, userLanguage});
 

--- a/test/qtiCommonRenderer/interactions/pci/ims/test.js
+++ b/test/qtiCommonRenderer/interactions/pci/ims/test.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
 
-define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function (ims) {
+define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims', 'context'], function (ims, sharedContext) {
     'use strict';
 
     QUnit.test('createInstance', function (assert) {
@@ -47,7 +47,9 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
             }
         };
         const response = { base: null };
-        const context = { response, locale: 'ru_RU' };
+        const context = { response };
+        //setup this once as because the context is shared
+        sharedContext.locale = 'ru_RU';
 
         const populatedProperties = Object.assign(properties, {
             language: 'ru_RU',
@@ -112,7 +114,7 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
             }
         };
         const response = { base: null };
-        const context = { response, locale: 'ru_RU' };
+        const context = { response };
 
         const populatedProperties = Object.assign(properties, {
             language: 'ru_BY',
@@ -225,7 +227,7 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
                         properties: {
                             "bar": "baz",
                             language: undefined,
-                            userLanguage: undefined
+                            userLanguage: "ru_RU"
                         },
                         status: 'interacting',
                         templateVariables: {}
@@ -253,7 +255,7 @@ define(['taoQtiItem/qtiCommonRenderer/renderers/interactions/pci/ims'], function
                         properties: {
                             "bar": "baz",
                             language: undefined,
-                            userLanguage: undefined
+                            userLanguage: "ru_RU"
                         },
                         status: 'interacting',
                         templateVariables: {}


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/TR-3246

### Description 

This fixes the misused context for userLanguage setup

### How to test

Run unit tests:

`npm run test:keepAlive`
copy the link from console and add `/qtiCommonRenderer/interactions/pci/ims/test.html` to it
`http://127.0.0.1:<port>/test/qtiCommonRenderer/interactions/pci/ims/test.html`

