### PR TITLE
Fix/tr-3274/associate images loading with wrong heights

### DIFF
--- a/src/qtiCommonRenderer/helpers/sizeAdapter.js
+++ b/src/qtiCommonRenderer/helpers/sizeAdapter.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015-2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA;
  *
  */
 import $ from 'jquery';
@@ -44,16 +44,22 @@ export default {
         }
 
         $container.waitForMedia(function () {
-            adaptSize.height($elements);
-            document.addEventListener(
-                'load',
-                e => {
-                    if (e.target && e.target.rel === 'stylesheet') {
-                        adaptSize.height($elements);
-                    }
-                },
-                true
-            );
+            // Occasionally in caching scenarios, after waitForMedia(), image.height is reporting its naturalHeight instead of its CSS height
+            // The timeout allows adaptSize.height() to work with the true rendered heights of elements, instead of naturalHeights
+            setTimeout(() => {
+                adaptSize.height($elements);
+
+                // detect any CSS load, and adapt heights again after
+                document.addEventListener(
+                    'load',
+                    e => {
+                        if (e.target && e.target.rel === 'stylesheet') {
+                            adaptSize.height($elements);
+                        }
+                    },
+                    true
+                );
+            }, 1);
         });
     }
 };


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-3274

### Issue

A bug where image height was detected as its full size (naturalHeight) just after it loads (possibly only in precaching test runner). Causes calculation result of container heights to be too large.

### Fix

Wrapping measurement code in `setTimeout(, 1)` seems to correct the height measurement, even after it loads with wrong size.

### To test

This bug doesn't reproduce often, but can sometimes be triggered by reloading the item before the Associate Interaction, then navigating to the next item. It's not necessary to interact. If DevTools are opened, browser cache option must not be disabled.

**Note:** add breakpoints or log the height values in these 2 places to see for yourself:
- `tao/views/node_modules/@oat-sa/tao-core-ui/dist/waitForMedia.js` -> inside `imageLoaded()`
- `tao/views/node_modules/@oat-sa/tao-core-sdk/dist/util/adaptSize.js` -> before `Math.max()` comparison

#### **Before fix:** 2 images load with naturalHeights, calculation result is too large
![Screenshot 2022-01-25 at 00 18 43](https://user-images.githubusercontent.com/43652944/150953650-410aa932-a437-429b-963b-7d5c5ade17b8.png)

#### **After fix:** 2 images load with naturalHeights, calculation result is correct
![Screenshot 2022-01-25 at 10 12 37](https://user-images.githubusercontent.com/43652944/150953677-aef7f4f7-57bd-440c-bc51-13ebaea2a735.png)
