### PR TITLE
fix: limit IME chars on extendedText maxLength

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -66,7 +66,7 @@ const render = function render(interaction) {
                 itemLocale = itemLang && itemLang.split('-')[0];
             }
             return itemLocale;
-        }
+        };
 
         const toolbarType = 'extendedText';
         const ckOptions = {
@@ -514,8 +514,8 @@ function inputLimiter(interaction) {
                                 logger.warn(`setText error ${err}!`);
                             }
                         } else {
-                            const totalValue = $textarea[0].value;
-                            $textarea[0].value = totalValue.substring(0, maxLength);
+                            const currentValue = $textarea[0].value;
+                            $textarea[0].value = currentValue.substring(0, maxLength);
                             $textarea[0].focus();
                         }
                     }
@@ -593,9 +593,10 @@ function inputLimiter(interaction) {
                 hasCompositionJustEnded = true;
                 // if plain text - then limit input right after composition end event
                 if (_getFormat(interaction) !== 'xhtml') {
-                    const totalValue = $textarea[0].value;
-                    $textarea[0].value = totalValue.substring(0, maxLength);
+                    const currentValue = $textarea[0].value;
+                    $textarea[0].value = currentValue.substring(0, maxLength);
                 }
+                _.defer(() => this.updateCounter());
                 return e;
             };
 
@@ -614,7 +615,9 @@ function inputLimiter(interaction) {
             } else {
                 $textarea
                     .on('beforeinput.commonRenderer', handleBeforeInput)
-                    .on('input.commonRenderer', () => _.defer(() => this.updateCounter()))
+                    .on('input.commonRenderer', () => {
+                        _.defer(() => this.updateCounter());
+                    })
                     .on('compositionstart.commonRenderer', handleCompositionStart)
                     .on('compositionend.commonRenderer', handleCompositionEnd)
                     .on('keyup.commonRenderer', patternHandler)

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -114,9 +114,12 @@ const render = function render(interaction) {
                     _styleUpdater();
                     const editable = this.editable();
                     let previousSnapshot = this.getSnapshot();
+                    const range = editor.createRange();
                     editable.on('input', () => {
                         if (limiter.getCharsCount() > limiter.maxLength) {
                             editable.setData(previousSnapshot, true);
+                            range.moveToElementEditablePosition(editable, true);
+                            editor.getSelection().selectRanges([range]);
                             return;
                         }
                         previousSnapshot = this.getSnapshot();

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -512,7 +512,7 @@ function inputLimiter(interaction) {
                         e.stopImmediatePropagation();
                     }
 
-                    if (this.getCharsCount() > maxLength) {
+                    if (this.getCharsCount() > maxLength && maxLength !== null) {
                         if (!isCke) {
                             const currentValue = $textarea[0].value;
                             $textarea[0].value = currentValue.substring(0, maxLength);

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -598,24 +598,24 @@ function inputLimiter(interaction) {
 
             if (_getFormat(interaction) === 'xhtml') {
                 cke = _getCKEditor(interaction);
-                if(maxLength){
-                    cke.on('instanceReady', function(){
-                        const editable = this.editable();
-                        let previousSnapshot = this.getSnapshot();
+
+                if (maxLength) {
+                    let previousSnapshot = cke.getSnapshot();
+
+                    cke.on('key', function () {
                         const range = this.createRange();
-                        editable.on('input', () => {
-                            if (limiter.getCharsCount() > limiter.maxLength) {
-                                editable.setData(previousSnapshot, true);
-                                range.moveToElementEditablePosition(editable, true);
-                                this.getSelection().selectRanges([range]);
-                                return;
-                            }
-                            previousSnapshot = this.getSnapshot();
-                        });
+                        if (limiter.getCharsCount() > limiter.maxLength) {
+                            const editable = this.editable();
+                            editable.setData(previousSnapshot, true);
+                            range.moveToElementEditablePosition(editable, true);
+                            cke.getSelection().selectRanges([range]);
+                            return;
+                        }
+                        previousSnapshot = cke.getSnapshot();
                     });
                 }
                 cke.on('key', keyLimitHandler);
-                cke.on('change', (evt) => {
+                cke.on('change', evt => {
                     patternHandler(evt);
                     _.defer(() => this.updateCounter());
                 });

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -606,7 +606,6 @@ function inputLimiter(interaction) {
 
             if (_getFormat(interaction) === 'xhtml') {
                 cke = _getCKEditor(interaction);
-                window.ckeinstance = cke;
                 cke.on('key', keyLimitHandler);
                 cke.on('change', patternHandler);
                 cke.on('paste', nonKeyLimitHandler);

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -592,7 +592,7 @@ function inputLimiter(interaction) {
                 isComposing = false;
                 hasCompositionJustEnded = true;
                 // if plain text - then limit input right after composition end event
-                if (_getFormat(interaction) !== 'xhtml') {
+                if (_getFormat(interaction) !== 'xhtml' && maxLength !== null) {
                     const currentValue = $textarea[0].value;
                     $textarea[0].value = currentValue.substring(0, maxLength);
                 }

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -112,18 +112,6 @@ const render = function render(interaction) {
 
                 editor.on('instanceReady', function () {
                     _styleUpdater();
-                    const editable = this.editable();
-                    let previousSnapshot = this.getSnapshot();
-                    const range = editor.createRange();
-                    editable.on('input', () => {
-                        if (limiter.getCharsCount() > limiter.maxLength) {
-                            editable.setData(previousSnapshot, true);
-                            range.moveToElementEditablePosition(editable, true);
-                            editor.getSelection().selectRanges([range]);
-                            return;
-                        }
-                        previousSnapshot = this.getSnapshot();
-                    });
 
                     //TAO-6409, disable navigation from cke toolbar
                     if (editor.container && editor.container.$) {
@@ -610,6 +598,22 @@ function inputLimiter(interaction) {
 
             if (_getFormat(interaction) === 'xhtml') {
                 cke = _getCKEditor(interaction);
+                if(maxLength){
+                    cke.on('instanceReady', function(){
+                        const editable = this.editable();
+                        let previousSnapshot = this.getSnapshot();
+                        const range = this.createRange();
+                        editable.on('input', () => {
+                            if (limiter.getCharsCount() > limiter.maxLength) {
+                                editable.setData(previousSnapshot, true);
+                                range.moveToElementEditablePosition(editable, true);
+                                this.getSelection().selectRanges([range]);
+                                return;
+                            }
+                            previousSnapshot = this.getSnapshot();
+                        });
+                    });
+                }
                 cke.on('key', keyLimitHandler);
                 cke.on('change', (evt) => {
                     patternHandler(evt);
@@ -929,7 +933,7 @@ function getCustomData(interaction, data) {
     return _.merge(data || {}, {
         maxWords: !isNaN(maxWords) ? maxWords : 0,
         maxLength: !isNaN(maxLength) ? maxLength : 0,
-        attributes: !isNaN(expectedLength) ? { expectedLength: expectedLength * 72 } : undefined
+        attributes: !isNaN(expectedLength) ? { expectedLength: expectedLength * 72 } : void 0
     });
 }
 

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -438,7 +438,6 @@ function inputLimiter(interaction) {
                 trigger: 'manual'
             });
             const patternHandler = function patternHandler(e) {
-                console.log('keyup');
                 if (isComposing || hasCompositionJustEnded) {
                     // IME composing fires keydown/keyup events
                     hasCompositionJustEnded = false;


### PR DESCRIPTION
**Related to:** [TR-3112](https://oat-sa.atlassian.net/browse/TR-3112)

**Description:**
IME characters are not being processed well with the pattern limit. I found a [CKEditor plugin](https://github.com/w8tcha/CKEditor-wordcount-Plugin) that supports it but we can't use it because we need to have separated the counter from the input. But it's handy to check how it manages IME characters. 

**Changes:**

- Add count bytes function to check the IME characters.
- Undo characters when they reach the limit. On CKEditor and on the textarea.

**How to check:**

- Install an IME tool on your OS, and enable the Japanese keyboard to write with it.
- Test on an ExtendedText interaction with length constrain pattern.
- Check if the limit works on English and on the IME language chosen.