### PR TITLE
Feat/AUT-345/messages for choices constraints

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -233,7 +233,7 @@ var _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if(!(max === 0 && max === 0 || max === 0 && max === 1)) {
+    } else if(!(min === 0 && (max === 0 || max === 1))) {
         // 1.No Constraints -> minChoices = 0, maxChoices = 0 -> No message
         // 2.Optional Single choice -> minChoices = 0, maxChoices = 1 -> No message
         // 7.Custom choices constraints -> any combination of minChoices & maxChoices -> “You must select from minChoices to maxChoices choices. for the correct answer“

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -216,9 +216,9 @@ const _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if (min >= 1 && max >= 2) {
+    } else if (min >= 1 && max >= 2 && min !== max) {
         // Multiple Choice: 5. Constraint: Other constraints -> “You must select from minChoices to maxChoices choices. for the correct answer“
-        msg = min !== max ? __('You need to select from %s to %s choices.', min, max) : __('You need to select %s choices.', min);
+        msg = __('You need to select from %s to %s choices.', min, max);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length < max) {
                 this.reset();

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -243,7 +243,7 @@ var _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if (min && min === max) {
+    } else if (min > 1 && min === max) {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices ≠ Disabled / maxChoices ≠ Disabled -> “You need to select {minChoices = maxChoices value} choices.“
         msg = __('You need to select %s choices', min);
         instructionMgr.appendInstruction(interaction, msg, function () {

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -280,7 +280,7 @@ var _setInstructions = function _setInstructions(interaction) {
         });
     } else if (min > 1 && (typeof max === 'undefined' || max === 0)) {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices ≠ Disabled / maxChoices = Disabled or 0   -> "You need to select at least {minChoices value} choices.""
-        msg = __('You need to select at least % choices.', min);
+        msg = __('You need to select at least %s choices.', min);
         instructionMgr.appendInstruction(interaction, msg, function () {
             if (_getRawResponse(interaction).length >= min) {
                 this.setLevel('success');

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -221,6 +221,7 @@ const _setInstructions = function _setInstructions(interaction) {
         msg = min !== max ? __('You need to select from %s to %s choices.', min, max) : __('You need to select %s choices.', min);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length < max) {
+                this.reset();
                 this.setLevel('success');
             } else if (_getRawResponse(interaction).length >= max) {
                 this.setMessage(__('Maximum choices reached'));

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -253,7 +253,7 @@ const _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if (max > 1 && typeof min === 'undefined') {
+    } else if (max > 1 && (typeof min === 'undefined' || max === 0)) {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices = Disabled / maxChoices ≠ Disabled  -> "You can select up to {maxChoices value} choices."
         msg = __('You can select up to %s choices.', max);
         instructionMgr.appendInstruction(interaction, msg, function (data) {

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -255,7 +255,7 @@ var _setInstructions = function _setInstructions(interaction) {
         });
     } else if (max > 1 && typeof min === 'undefined') {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices = Disabled / maxChoices ≠ Disabled  -> "You can select up to {maxChoices value} choices."
-        msg = __('You can select up to % choices.', max);
+        msg = __('You can select up to %s choices.', max);
         instructionMgr.appendInstruction(interaction, msg, function(data) {
             if (_getRawResponse(interaction).length >= max) {
                 this.setMessage(__('Maximum choices reached'));

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -218,7 +218,7 @@ const _setInstructions = function _setInstructions(interaction) {
         });
     } else if (min >= 1 && max >= 2) {
         // Multiple Choice: 5. Constraint: Other constraints -> “You must select from minChoices to maxChoices choices. for the correct answer“
-        msg = min !== 1 && max ? __('You need to select from %s to %s choices.', min, max) : __('You need to select %s choices.', min);
+        msg = min !== max ? __('You need to select from %s to %s choices.', min, max) : __('You need to select %s choices.', min);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length <= max) {
                 this.setLevel('success');

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -218,7 +218,7 @@ const _setInstructions = function _setInstructions(interaction) {
         });
     } else if (min >= 1 && max >= 2) {
         // Multiple Choice: 5. Constraint: Other constraints -> “You must select from minChoices to maxChoices choices. for the correct answer“
-        msg = __('You need to select from %s to %s choices.', min, max);
+        msg = min !== 1 && max ? __('You need to select from %s to %s choices.', min, max) : __('You need to select %s choices.', min);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length <= max) {
                 this.setLevel('success');
@@ -253,7 +253,7 @@ const _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if (max > 1 && (typeof min === 'undefined' || min === 0)) {
+    } else if (max > 1 && max < choiceCount && (typeof min === 'undefined' || min === 0)) {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices = Disabled / maxChoices ≠ Disabled  -> "You can select up to {maxChoices value} choices."
         msg = __('You can select up to %s choices.', max);
         instructionMgr.appendInstruction(interaction, msg, function (data) {

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -31,12 +31,12 @@ import pciResponse from 'taoQtiItem/qtiCommonRenderer/helpers/PciResponse';
 import sizeAdapter from 'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter';
 import adaptSize from 'util/adaptSize';
 
-var KEY_CODE_SPACE = 32;
-var KEY_CODE_ENTER = 13;
-var KEY_CODE_LEFT = 37;
-var KEY_CODE_UP = 38;
-var KEY_CODE_RIGHT = 39;
-var KEY_CODE_DOWN = 40;
+const KEY_CODE_SPACE = 32;
+const KEY_CODE_ENTER = 13;
+const KEY_CODE_LEFT = 37;
+const KEY_CODE_UP = 38;
+const KEY_CODE_RIGHT = 39;
+const KEY_CODE_DOWN = 40;
 
 /**
  * Propagate the checked state to the actual input.
@@ -45,9 +45,9 @@ var KEY_CODE_DOWN = 40;
  * @param {Boolean} state
  * @private
  */
-var _triggerInput = function _triggerInput($choiceBox, state) {
-    var $input = $choiceBox.find('input:radio,input:checkbox').not('[disabled]').not('.disabled');
-    var $choiceBoxes = $choiceBox.add($choiceBox.siblings());
+const _triggerInput = function _triggerInput($choiceBox, state) {
+    const $input = $choiceBox.find('input:radio,input:checkbox').not('[disabled]').not('.disabled');
+    const $choiceBoxes = $choiceBox.add($choiceBox.siblings());
 
     if (!$input.length) {
         return;
@@ -77,15 +77,15 @@ var _triggerInput = function _triggerInput($choiceBox, state) {
  * @param {Object} interaction - the interaction instance
  * @param {jQueryElement} $container
  */
-var _pseudoLabel = function _pseudoLabel(interaction, $container) {
-    var inputSelector =
+const _pseudoLabel = function _pseudoLabel(interaction, $container) {
+    const inputSelector =
         '.qti-choice input:radio:not([disabled]):not(.disabled), .qti-choice input:checkbox:not([disabled]):not(.disabled)';
     $container.off('.commonRenderer');
 
     $container
         .on('keydown.commonRenderer.keyNavigation', inputSelector, function (e) {
-            var $qtiChoice = $(this).closest('.qti-choice');
-            var keyCode = e.keyCode ? e.keyCode : e.charCode;
+            const $qtiChoice = $(this).closest('.qti-choice');
+            const keyCode = e.keyCode ? e.keyCode : e.charCode;
 
             if (keyCode === KEY_CODE_UP || keyCode === KEY_CODE_LEFT) {
                 e.preventDefault();
@@ -108,7 +108,7 @@ var _pseudoLabel = function _pseudoLabel(interaction, $container) {
             }
         })
         .on('keyup.commonRenderer.keyNavigation', inputSelector, function (e) {
-            var keyCode = e.keyCode ? e.keyCode : e.charCode;
+            const keyCode = e.keyCode ? e.keyCode : e.charCode;
 
             if (keyCode === KEY_CODE_SPACE || keyCode === KEY_CODE_ENTER) {
                 e.preventDefault();
@@ -118,10 +118,10 @@ var _pseudoLabel = function _pseudoLabel(interaction, $container) {
         });
 
     $container.on('click.commonRenderer', '.qti-choice', function (e) {
-        var $choiceBox = $(this);
-        var state;
-        var eliminator = e.target.dataset && e.target.dataset.eliminable;
-        var input = this.querySelector('.real-label > input');
+        const $choiceBox = $(this);
+        let state;
+        const eliminator = e.target.dataset && e.target.dataset.eliminable;
+        const input = this.querySelector('.real-label > input');
 
         // if the click has been triggered by a keyboard check, prevent this listener to cancel this check
         if (e.originalEvent && $(e.originalEvent.target).is('input')) {
@@ -163,9 +163,9 @@ var _pseudoLabel = function _pseudoLabel(interaction, $container) {
  * @param {Object} interaction - the interaction instance
  * @returns {Array} the list of choices identifiers
  */
-var _getRawResponse = function _getRawResponse(interaction) {
-    var values = [];
-    var $container = containerHelper.get(interaction);
+const _getRawResponse = function _getRawResponse(interaction) {
+    const values = [];
+    const $container = containerHelper.get(interaction);
     $('.real-label > input[name=response-' + interaction.getSerial() + ']:checked', $container).each(function () {
         values.push($(this).val());
     });
@@ -177,17 +177,17 @@ var _getRawResponse = function _getRawResponse(interaction) {
  * @private
  * @param {Object} interaction - the interaction instance
  */
-var _setInstructions = function _setInstructions(interaction) {
-    var min = interaction.attr('minChoices'),
-        max = interaction.attr('maxChoices'),
-        msg,
-        choiceCount = _.size(interaction.getChoices());
+const _setInstructions = function _setInstructions(interaction) {
+    const min = interaction.attr('minChoices');
+    const max = interaction.attr('maxChoices');
+    let msg;
+    const choiceCount = _.size(interaction.getChoices());
 
-    var highlightInvalidInput = function highlightInvalidInput($choice) {
-        var $input = $choice.find('.real-label > input'),
-            $li = $choice.css('color', '#BA122B'),
-            $icon = $choice.find('.real-label > span').css('color', '#BA122B').addClass('cross error');
-        var timeout = interaction.data('__instructionTimeout');
+    const highlightInvalidInput = function highlightInvalidInput($choice) {
+        const $input = $choice.find('.real-label > input');
+        const $li = $choice.css('color', '#BA122B');
+        const $icon = $choice.find('.real-label > span').css('color', '#BA122B').addClass('cross error');
+        let timeout = interaction.data('__instructionTimeout');
 
         if (timeout) {
             clearTimeout(timeout);
@@ -256,19 +256,19 @@ var _setInstructions = function _setInstructions(interaction) {
     } else if (max > 1 && typeof min === 'undefined') {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices = Disabled / maxChoices ≠ Disabled  -> "You can select up to {maxChoices value} choices."
         msg = __('You can select up to %s choices.', max);
-        instructionMgr.appendInstruction(interaction, msg, function(data) {
+        instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= max) {
                 this.setMessage(__('Maximum choices reached'));
                 if (this.checkState('fulfilled')) {
                     this.update({
                         level: 'warning',
                         timeout: 2000,
-                        start: function() {
+                        start: function () {
                             if (data && data.choice) {
                                 highlightInvalidInput(data.choice);
                             }
                         },
-                        stop: function() {
+                        stop: function () {
                             this.setLevel('info');
                         }
                     });
@@ -301,8 +301,8 @@ var _setInstructions = function _setInstructions(interaction) {
  *
  * @param {Object} interaction - the interaction instance
  */
-var render = function render(interaction) {
-    var $container = containerHelper.get(interaction);
+const render = function render(interaction) {
+    const $container = containerHelper.get(interaction);
 
     _pseudoLabel(interaction, $container);
 
@@ -321,8 +321,8 @@ var render = function render(interaction) {
  *
  * @param {Object} interaction - the interaction instance
  */
-var resetResponse = function resetResponse(interaction) {
-    var $container = containerHelper.get(interaction);
+const resetResponse = function resetResponse(interaction) {
+    const $container = containerHelper.get(interaction);
 
     $('.real-label > input', $container).prop('checked', false);
 };
@@ -340,12 +340,12 @@ var resetResponse = function resetResponse(interaction) {
  * @param {Object} interaction - the interaction instance
  * @param {0bject} response - the PCI formated response
  */
-var setResponse = function setResponse(interaction, response) {
-    var $container = containerHelper.get(interaction);
+const setResponse = function setResponse(interaction, response) {
+    const $container = containerHelper.get(interaction);
 
     try {
         _.forEach(pciResponse.unserialize(response, interaction), function (identifier) {
-            var $input = $container.find('.real-label > input[value="' + identifier + '"]').prop('checked', true);
+            const $input = $container.find('.real-label > input[value="' + identifier + '"]').prop('checked', true);
             $input.closest('.qti-choice').toggleClass('user-selected', true);
         });
         instructionMgr.validateInstructions(interaction);
@@ -366,7 +366,7 @@ var setResponse = function setResponse(interaction, response) {
  * @param {Object} interaction - the interaction instance
  * @returns {Object} the response formatted in PCI
  */
-var getResponse = function getResponse(interaction) {
+const getResponse = function getResponse(interaction) {
     return pciResponse.serialize(_getRawResponse(interaction), interaction);
 };
 
@@ -376,7 +376,7 @@ var getResponse = function getResponse(interaction) {
  * @param {Object} interaction
  * @returns {boolean}
  */
-var isEliminable = function isEliminable(interaction) {
+const isEliminable = function isEliminable(interaction) {
     return /\beliminable\b/.test(interaction.attr('class'));
 };
 
@@ -386,8 +386,8 @@ var isEliminable = function isEliminable(interaction) {
  * @param {Object} [data] - interaction custom data
  * @returns {Object} custom data
  */
-var getCustomData = function getCustomData(interaction, data) {
-    var listStyles = (interaction.attr('class') || '').match(/\blist-style-[\w-]+/) || [];
+const getCustomData = function getCustomData(interaction, data) {
+    const listStyles = (interaction.attr('class') || '').match(/\blist-style-[\w-]+/) || [];
     return _.merge(data || {}, {
         horizontal: interaction.attr('orientation') === 'horizontal',
         listStyle: listStyles.pop(),
@@ -399,10 +399,10 @@ var getCustomData = function getCustomData(interaction, data) {
  * Destroy the interaction by leaving the DOM exactly in the same state it was before loading the interaction.
  * @param {Object} interaction - the interaction
  */
-var destroy = function destroy(interaction) {
-    var $container = containerHelper.get(interaction);
+const destroy = function destroy(interaction) {
+    const $container = containerHelper.get(interaction);
 
-    var timeout = interaction.data('__instructionTimeout');
+    const timeout = interaction.data('__instructionTimeout');
 
     if (timeout) {
         clearTimeout(timeout);
@@ -425,23 +425,21 @@ var destroy = function destroy(interaction) {
  * @param {Object} interaction - the interaction instance
  * @param {Object} state - the interaction state
  */
-var setState = function setState(interaction, state) {
-    var $container;
-
+const setState = function setState(interaction, state) {
     if (_.isObject(state)) {
         if (state.response) {
             interaction.resetResponse();
             interaction.setResponse(state.response);
         }
 
-        $container = containerHelper.get(interaction);
+        const $container = containerHelper.get(interaction);
 
         //restore order of previously shuffled choices
         if (_.isArray(state.order) && state.order.length === _.size(interaction.getChoices())) {
             $('.qti-simpleChoice', $container)
                 .sort(function (a, b) {
-                    var aIndex = _.indexOf(state.order, $(a).data('identifier'));
-                    var bIndex = _.indexOf(state.order, $(b).data('identifier'));
+                    const aIndex = _.indexOf(state.order, $(a).data('identifier'));
+                    const bIndex = _.indexOf(state.order, $(b).data('identifier'));
                     if (aIndex > bIndex) {
                         return 1;
                     }
@@ -469,10 +467,10 @@ var setState = function setState(interaction, state) {
  * @param {Object} interaction - the interaction instance
  * @returns {Object} the interaction current state
  */
-var getState = function getState(interaction) {
-    var $container = containerHelper.get(interaction);
-    var state = {};
-    var response = interaction.getResponse();
+const getState = function getState(interaction) {
+    const $container = containerHelper.get(interaction);
+    const state = {};
+    const response = interaction.getResponse();
 
     if (response) {
         state.response = response;

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -220,10 +220,9 @@ const _setInstructions = function _setInstructions(interaction) {
         // Multiple Choice: 5. Constraint: Other constraints -> “You must select from minChoices to maxChoices choices. for the correct answer“
         msg = min !== max ? __('You need to select from %s to %s choices.', min, max) : __('You need to select %s choices.', min);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
-            if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length <= max) {
+            if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length < max) {
                 this.setLevel('success');
-            }
-            if (_getRawResponse(interaction).length >= max) {
+            } else if (_getRawResponse(interaction).length >= max) {
                 this.setMessage(__('Maximum choices reached'));
                 if (this.checkState('fulfilled')) {
                     this.update({

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -209,7 +209,7 @@ var _setInstructions = function _setInstructions(interaction) {
         // Single choice: 2.Constraint: Answer required  -> minChoices = 1, maxChoices = 1 -> “You need to select at least 1 choice”
         // Multiple Choice: 4.Constraint: Answer required -> minChoices = 1 / maxChoices = 0 -> “You need to select at least 1 choice”
         // Multiple Choice: 5.Constraint: Other constraints -> minChoices = 1 / maxChoices = (N or Disabled)
-        msg = __('You need to select at least 1 choice');
+        msg = __('You need to select at least 1 choice.');
         instructionMgr.appendInstruction(interaction, msg, function () {
             if (_getRawResponse(interaction).length >= 1) {
                 this.setLevel('success');
@@ -219,7 +219,7 @@ var _setInstructions = function _setInstructions(interaction) {
         });
     } else if (min >=1 && max >=2) {
         // Multiple Choice: 5. Constraint: Other constraints -> “You must select from minChoices to maxChoices choices. for the correct answer“
-        msg = __('You must select from %s to %s choices.', min, max);
+        msg = __('You need to select from %s to %s choices.', min, max);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length <= max) {
                 this.setLevel('success');

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -222,7 +222,8 @@ const _setInstructions = function _setInstructions(interaction) {
         instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length <= max) {
                 this.setLevel('success');
-            } else if (_getRawResponse(interaction).length >= max) {
+            }
+            if (_getRawResponse(interaction).length >= max) {
                 this.setMessage(__('Maximum choices reached'));
                 if (this.checkState('fulfilled')) {
                     this.update({

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -218,6 +218,7 @@ var _setInstructions = function _setInstructions(interaction) {
     } else if (max === choiceCount && min === 0) {
     // 4.Optional Multiple choices -> minChoices = 0, maxChoices = NumberOfChoicesDefined -> “You can select up to maxChoices as correct answer.”
         msg = __('You can select up to %s as correct answer.', max);
+        instructionMgr.appendInstruction(interaction, msg);
     } else if (min === 1) {
     // 5.Required Single answer up to limit on Multiple choices -> minChoices = 1, maxChoices = NumberOfChoicesDefined -> “You MUST define a least 1 choice as the correct answer up to maxChoices “
     // 6.Required Answer -> minChoices = 1 , maxChoices = 0 -> “You MUST define a least 1 choice for the correct answer“

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -217,9 +217,9 @@ var _setInstructions = function _setInstructions(interaction) {
         });
     } else if (max === choiceCount && min === 0) {
     // 4.Optional Multiple choices -> minChoices = 0, maxChoices = NumberOfChoicesDefined -> “You can select up to maxChoices as correct answer.”
-        msg = __('You can select up to %s as correct answer.', max);
+        msg = __('You can select up to %s as correct answer', max);
         instructionMgr.appendInstruction(interaction, msg);
-    } else if (min === 1) {
+    } else if (min === 1 && (max === 0 || max === choiceCount)) {
     // 5.Required Single answer up to limit on Multiple choices -> minChoices = 1, maxChoices = NumberOfChoicesDefined -> “You MUST define a least 1 choice as the correct answer up to maxChoices “
     // 6.Required Answer -> minChoices = 1 , maxChoices = 0 -> “You MUST define a least 1 choice for the correct answer“
         msg =
@@ -237,7 +237,7 @@ var _setInstructions = function _setInstructions(interaction) {
         // 1.No Constraints -> minChoices = 0, maxChoices = 0 -> No message
         // 2.Optional Single choice -> minChoices = 0, maxChoices = 1 -> No message
         // 7.Custom choices constraints -> any combination of minChoices & maxChoices -> “You must select from minChoices to maxChoices choices. for the correct answer“
-        msg = __('You must select from %s to %s choices for the correct answer', min, max);
+        msg = __('You must select from %s to %s choices for the correct answer', min || 0, max || 1);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length >= min && _getRawResponse(interaction).length <= max) {
                 this.setLevel('success');

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -217,7 +217,7 @@ var _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if (min >=1 && max >=2) {
+    } else if (min >= 1 && max >= 2) {
         // Multiple Choice: 5. Constraint: Other constraints -> “You must select from minChoices to maxChoices choices. for the correct answer“
         msg = __('You need to select from %s to %s choices.', min, max);
         instructionMgr.appendInstruction(interaction, msg, function (data) {
@@ -245,10 +245,45 @@ var _setInstructions = function _setInstructions(interaction) {
             }
         });
     } else if (min && min === max) {
-        // Multiple Choice: 5. Constraint: Other constraints -> “You need to select {minChoices = maxChoices value} choices.“
+        // Multiple Choice: 5. Constraint: Other constraints -> minChoices ≠ Disabled / maxChoices ≠ Disabled -> “You need to select {minChoices = maxChoices value} choices.“
         msg = __('You need to select %s choices', min);
         instructionMgr.appendInstruction(interaction, msg, function () {
             if (_getRawResponse(interaction).length === min) {
+                this.setLevel('success');
+            } else {
+                this.reset();
+            }
+        });
+    } else if (max > 1 && typeof min === 'undefined') {
+        // Multiple Choice: 5. Constraint: Other constraints -> minChoices = Disabled / maxChoices ≠ Disabled  -> "You can select up to {maxChoices value} choices."
+        msg = __('You can select up to % choices.', max);
+        instructionMgr.appendInstruction(interaction, msg, function(data) {
+            if (_getRawResponse(interaction).length >= max) {
+                this.setMessage(__('Maximum choices reached'));
+                if (this.checkState('fulfilled')) {
+                    this.update({
+                        level: 'warning',
+                        timeout: 2000,
+                        start: function() {
+                            if (data && data.choice) {
+                                highlightInvalidInput(data.choice);
+                            }
+                        },
+                        stop: function() {
+                            this.setLevel('info');
+                        }
+                    });
+                }
+                this.setState('fulfilled');
+            } else {
+                this.reset();
+            }
+        });
+    } else if (min > 1 && typeof max === 'undefined') {
+        // Multiple Choice: 5. Constraint: Other constraints -> minChoices ≠ Disabled / maxChoices = Disabled   -> "You need to select at least {minChoices value} choices.""
+        msg = __('You need to select at least % choices.', min);
+        instructionMgr.appendInstruction(interaction, msg, function () {
+            if (_getRawResponse(interaction).length >= min) {
                 this.setLevel('success');
             } else {
                 this.reset();

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -253,7 +253,7 @@ const _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if (max > 1 && (typeof min === 'undefined' || max === 0)) {
+    } else if (max > 1 && (typeof min === 'undefined' || min === 0)) {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices = Disabled / maxChoices ≠ Disabled  -> "You can select up to {maxChoices value} choices."
         msg = __('You can select up to %s choices.', max);
         instructionMgr.appendInstruction(interaction, msg, function (data) {

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -205,8 +205,7 @@ var _setInstructions = function _setInstructions(interaction) {
     // if maxChoice = 1, use the radio group behaviour
     // if maxChoice = 0, infinite choice possible
     // there are 5 cases according AUT-345 Choice interaction: reduce edge cases constraints
-    if (min === 1 && (max === 1 || max === 0 || max === choiceCount || typeof max === 'undefined')) {
-        // Single choice: 2.Constraint: Answer required  -> minChoices = 1, maxChoices = 1 -> “You need to select at least 1 choice”
+    if (min === 1 && (max === 0 || max === choiceCount || typeof max === 'undefined')) {
         // Multiple Choice: 4.Constraint: Answer required -> minChoices = 1 / maxChoices = 0 -> “You need to select at least 1 choice”
         // Multiple Choice: 5.Constraint: Other constraints -> minChoices = 1 / maxChoices = (N or Disabled)
         msg = __('You need to select at least 1 choice.');
@@ -290,6 +289,9 @@ var _setInstructions = function _setInstructions(interaction) {
             }
         });
     }
+    // Single choice: 1.Constraint: None -> minChoices = 0 / maxChoices = 1 -> No messages
+    // Single choice: 2.Constraint: Answer required  -> minChoices = 1, maxChoices = 1 -> No messages
+    // Multiple Choice: 3.Constraint: None  -> minChoices = 0, maxChoices = 0 -> No messages
 };
 
 /**

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -278,8 +278,8 @@ var _setInstructions = function _setInstructions(interaction) {
                 this.reset();
             }
         });
-    } else if (min > 1 && typeof max === 'undefined') {
-        // Multiple Choice: 5. Constraint: Other constraints -> minChoices ≠ Disabled / maxChoices = Disabled   -> "You need to select at least {minChoices value} choices.""
+    } else if (min > 1 && (typeof max === 'undefined' || max === 0)) {
+        // Multiple Choice: 5. Constraint: Other constraints -> minChoices ≠ Disabled / maxChoices = Disabled or 0   -> "You need to select at least {minChoices value} choices.""
         msg = __('You need to select at least % choices.', min);
         instructionMgr.appendInstruction(interaction, msg, function () {
             if (_getRawResponse(interaction).length >= min) {

--- a/test/qtiCommonRenderer/interactions/choice/test.js
+++ b/test/qtiCommonRenderer/interactions/choice/test.js
@@ -13,7 +13,7 @@ define([
     var outsideContainerId = 'outside-container';
 
     QUnit.module('Choice Interaction', {
-        afterEach: function(assert) {
+        afterEach: function() {
             if (runner) {
                 runner.clear();
             }
@@ -22,7 +22,7 @@ define([
 
     QUnit.test('renders correclty', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
 
         assert.expect(17);
 
@@ -115,7 +115,7 @@ define([
 
     QUnit.test('enables to select a choice', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
 
         assert.expect(8);
 
@@ -156,7 +156,7 @@ define([
 
     QUnit.test('enables to select a unique choice', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
         var changes = 0;
 
         assert.expect(11);
@@ -217,7 +217,7 @@ define([
 
     QUnit.test('enables to select multiple choices', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
         var changes = 0;
 
         assert.expect(11);
@@ -276,7 +276,7 @@ define([
 
     QUnit.test('set the default response', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
 
         assert.expect(4);
 
@@ -305,7 +305,7 @@ define([
 
     QUnit.test('destroys', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
 
         assert.expect(5);
 
@@ -346,7 +346,7 @@ define([
 
     QUnit.test('resets the response', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
 
         assert.expect(7);
 
@@ -393,7 +393,7 @@ define([
 
     QUnit.test('restores order of shuffled choices', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
         var shuffled;
 
         assert.expect(9);
@@ -461,7 +461,7 @@ define([
 
     QUnit.test('get eliminated choices state', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
         var $discovery, $challenger, $pathfinder, $atlantis, $endeavour;
         var shuffled;
 
@@ -523,7 +523,7 @@ define([
         // Note: toggling state via events makes for unruly state management (and thus this mess of a test)
         var $eliminator;
         var $choice;
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
         var shuffled;
 
         assert.expect(3);
@@ -564,7 +564,7 @@ define([
 
     QUnit.test('check dashes and dots in the identifier', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + fixtureContainerId);
+        var $container = $(`#${fixtureContainerId}`);
 
         assert.expect(4);
 
@@ -593,7 +593,7 @@ define([
 
     QUnit.test('Display and play', function(assert) {
         var ready = assert.async();
-        var $container = $('#' + outsideContainerId);
+        var $container = $(`#${outsideContainerId}`);
 
         assert.expect(4);
 

--- a/test/qtiCommonRenderer/interactions/choice/test.js
+++ b/test/qtiCommonRenderer/interactions/choice/test.js
@@ -247,8 +247,8 @@ define([
                 );
                 assert.equal(
                     $container.find('.qti-choiceInteraction .instruction-container').children().length,
-                    2,
-                    'the interaction has 2 instructions'
+                    1,
+                    'the interaction has 1 instructions'
                 );
                 assert.equal($discovery.length, 1, 'the Discovery choice exists');
                 assert.equal($discovery.length, 1, 'the Challenger choice exists');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-345
<img width="1144" alt="image" src="https://user-images.githubusercontent.com/25976342/158422954-8fefa7ce-3fec-4541-80ce-6b1bcd374531.png">

**Acceptance criteria**
GIVEN a choiceInteraction with N defined number of choices:
AC2: Response properties

GIVEN AC1a
WHEN user navigates to Response tab of the choiceInteraction widget
THEN TAO, based on the predefined or custom options selected for the choice constraints, shall present the following messages:

Single choice:
    1. Constraint: None → Please define the correct response below.
    2. Constraint: Answer required → Please define the correct response below.

Multiple Choice:
    3. Constraint: None → Please define the correct response below.
    4. Constraint: Answer required → Please define the correct response below. / You need to select at least 1 choice.
    5. Constraint: Other constraints →
         a. minChoices ≠ Disabled / maxChoices ≠ Disabled -> Please define the correct response below. / You need to select from    {minChoices value} to {maxChoices value} choices.
         b. minChoices ≠ Disabled / maxChoices = Disabled -> Please define the correct response below. / You need to select at least {minChoices value} choices.
         c. minChoices = Disabled / maxChoices ≠ Disabled -> Please define the correct response below. / You can select up to {maxChoices value} choices.
         d. minChoices = maxChoices -> Please define the correct response below. / You need to select {minChoices = maxChoices value} choices.