### PR TITLE
feat: add maxscore outcome to PCI on Match Correct Responses

### DIFF
--- a/src/qtiItem/core/interactions/CustomInteraction.js
+++ b/src/qtiItem/core/interactions/CustomInteraction.js
@@ -3,6 +3,7 @@ import Interaction from 'taoQtiItem/qtiItem/core/interactions/Interaction';
 import CustomElement from 'taoQtiItem/qtiItem/mixin/CustomElement';
 import NamespacedElement from 'taoQtiItem/qtiItem/mixin/NamespacedElement';
 import rendererConfig from 'taoQtiItem/qtiItem/helper/rendererConfig';
+import maxScore from 'taoQtiItem/qtiItem/helper/maxScore';
 
 var CustomInteraction = Interaction.extend({
     qtiClass: 'customInteraction',
@@ -129,6 +130,9 @@ var CustomInteraction = Interaction.extend({
             }
         });
         return this;
+    },
+    getNormalMaximum: function getNormalMaximum() {
+        return maxScore.pciInteraction(this);
     }
 });
 

--- a/src/qtiItem/core/interactions/CustomInteraction.js
+++ b/src/qtiItem/core/interactions/CustomInteraction.js
@@ -131,8 +131,8 @@ var CustomInteraction = Interaction.extend({
         });
         return this;
     },
-    getNormalMaximum: function getNormalMaximum() {
-        return maxScore.pciInteraction(this);
+    getNormalMaximum() {
+        return maxScore.customInteractionBased(this);
     }
 });
 

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -823,13 +823,13 @@ export default {
         }
         return max;
     },
-    pciInteraction: function pciInteraction(interaction) {
+    customInteractionBased(interaction) {
         var responseDeclaration = interaction.getResponseDeclaration();
         var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
         var max;
         if (template === 'MATCH_CORRECT') {
             if (
-                _.isArray(responseDeclaration.correctResponse) &&
+                Array.isArray(responseDeclaration.correctResponse) &&
                 (responseDeclaration.correctResponse.length)
             ) {
                 max = 1;

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -824,9 +824,9 @@ export default {
         return max;
     },
     customInteractionBased(interaction) {
-        var responseDeclaration = interaction.getResponseDeclaration();
-        var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
-        var max;
+        const responseDeclaration = interaction.getResponseDeclaration();
+        const template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
+        let max;
         if (template === 'MATCH_CORRECT') {
             if (
                 Array.isArray(responseDeclaration.correctResponse) &&
@@ -836,6 +836,8 @@ export default {
             } else {
                 max = 0;
             }
+        } else {
+            max = 0;
         }
         return max;
     }

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -822,5 +822,21 @@ export default {
             max = 0;
         }
         return max;
+    },
+    pciInteraction: function pciInteraction(interaction) {
+        var responseDeclaration = interaction.getResponseDeclaration();
+        var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
+        var max;
+        if (template === 'MATCH_CORRECT') {
+            if (
+                _.isArray(responseDeclaration.correctResponse) &&
+                (responseDeclaration.correctResponse.length)
+            ) {
+                max = 1;
+            } else {
+                max = 0;
+            }
+        }
+        return max;
     }
 };

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -823,6 +823,12 @@ export default {
         }
         return max;
     },
+
+    /**
+     * Compute the maximum score of a "custom" typed interaction
+     * @param {Object} interaction - a standard interaction model object
+     * @returns {Number}
+     */
     customInteractionBased(interaction) {
         const responseDeclaration = interaction.getResponseDeclaration();
         const template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);

--- a/test/qtiItem/maxScore/test.js
+++ b/test/qtiItem/maxScore/test.js
@@ -216,7 +216,7 @@ define([
             maxScore: 4
         },
         { title: 'upload', data: dataUpload, expectedMaximum: undefined, maxScore: undefined },
-        { title: 'custom interaction', data: dataPci, expectedMaximum: undefined, maxScore: undefined },
+        { title: 'custom interaction', data: dataPci, expectedMaximum: 0, maxScore: 0 },
         { title: 'custom response processing', data: dataCustomRp, expectedMaximum: undefined, maxScore: undefined },
         {
             title: 'upload and choice - correct',


### PR DESCRIPTION
**Related to:** [AUT-507](https://oat-sa.atlassian.net/browse/AUT-507)

**Description:**
on Match Correct response mode, we want to increment the MAXSCORE number with every interaction are added to the Item, even if it is a PCI.

**Changes:**

- Add a connection between CustomInteraction and the NomalMaximum param that MAXCORE depends on.
- Condition to be on Match Correct response mode and have a correct response declaration.

**How to check:**

- Add a PCI item with response mode, like Liquids. Set a correct response.
- Save it and check the XML on the `saveItem` action payload. Must have the param `normalMaximum` and the MAXSCORE outcome.
```
<outcomeDeclaration cardinality="single" baseType="float" identifier="SCORE" normalMaximum="1"/>
<outcomeDeclaration cardinality="single" baseType="float" identifier="MAXSCORE">
    <defaultValue>
        <value>1</value>
    </defaultValue>
</outcomeDeclaration>
```
- Now add a Choice Interaction to the same Item. Set a correct response.
- Save it and check that now the MAXSCORE has sum both interactions and now it is a 2
- Play with this Interactions with and without correct response declaration settings to see if it sum or not only the number of interactions with correct response declaration don't the March Correct.