### PR TITLE
fix/LSI-644_call-resize-on-ready

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -135,6 +135,9 @@ function render(interaction) {
                             this.disable();
                         }
 
+                        // on slow network the resize runs before ready, so it should be called again
+                        resize();
+
                         // declare the item ready when player is ready to play.
                         resolve();
                     })


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/LSI-644

On slow network connection, the resize is called earlier than ready, so the container does not adapt to the video size.

Test:
I cannot reproduce locally, so what I did is the following:

- I installed a local environment based on https://github.com/oat-sa/tao-enterprise-depp/blob/v0.134.5.106-alpha/composer.json
- I added `resize` call to `taoQtiItem/views/node_modules/@oat-sa/tao-item-runner-qti/dist/qtiCommonRenderer/renderers/interactions/MediaInteraction.js`
- I bundled taoQtiItem with `npx grunt taoqtiitembundle`
- I installed Proxyman (https://proxyman.io/)
- I set `Map locale` for https://integration-2donline.depp.taocloud.fr/__cdn/taoItems/views/js/loader/taoItemsRunner.min.js?buster=611f9815af232 to load my newly bundled js file
- I set `Network condition` to slow, because I was able to reproduce the issue constantly with that.
- If I took the test, I was not able to reproduce the issue. I see a small glitch (<0.5 sec), when it is wrong, but when the video `ready` is reached and my `resize` is called, everything became normal. 