### PR TITLE
fix: select2 dropdown RTL

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -64,7 +64,7 @@ var render = function(interaction, options) {
     }
 
     const getItemDir = () => {
-        const itemBody = $container.closest('.qti-itemBody');
+        const itemBody = $('.qti-itemBody');
         const itemDir = itemBody.attr('dir') || 'ltr';
         return itemDir;
     }


### PR DESCRIPTION
Related to:
https://oat-sa.atlassian.net/browse/AUT-2123
https://github.com/oat-sa/extension-tao-itemqti/pull/2104

Fix inline interaction responses box not aligned correctly for RTL when first saved as LTR. 
Solution for **widget RESPONSE** side.

SETPS to test:
• Checkout to branch: fix/fix/AUT-2123/inlinechoice-interaction-responses-not-aligned-when-initially-saved-LTR
•Create an item
•Add a text block.
•Add an Inline Choice interaction.
•Click save with default language (LTR)
•Re-open and change language to RTL

**ACTUAL RESULT:**
the widget with the choices doesn't show the RTL alignment as the rest of the item.

**EXPECTED RESULT:**
When opening responses box alignment should be RTL  please make sure that you check in the RESPONSE" tickbox.

**CHANGES:**
`$ItemBody` wasn't getting the item but a select which didn't have the attr dir, changed selector so it selects item which contains dir.
![image](https://user-images.githubusercontent.com/60346520/163996507-82dfafcf-deae-4998-b09d-eb1aaa68e464.png)

