### PR TITLE
fix: PortableCustomInteraction renderer need function to use this

### DIFF
--- a/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -26,7 +26,7 @@ import util from 'taoQtiItem/qtiItem/helper/util';
 import PortableElement from 'taoQtiItem/qtiCommonRenderer/helpers/PortableElement';
 import { isInteractionDisabledForPci } from 'taoQtiItem/reviewRenderer/helpers/pci';
 
-const getData = (customInteraction, data) => {
+const getData = function (customInteraction, data) {
     let markup = data.markup;
     const isInteractionDisabled = isInteractionDisabledForPci(data.typeIdentifier);
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2151

**On line 38 we need this === renderer** 
`markup = PortableElement.fixMarkupMediaSources(markup, this);`

**Preconditions:**
Item with Math entry PCI with the picture in prompt added to the test
Test passed by TT or guest

**Steps to reproduce:**

- Go to results tab and select the test
- Click “View“ 
- Click “Review“

**Actual result:** Math entry PCI interaction is not displayed in Test Review mode. error pops-up. Error in console

**Expected result:** Math entry PCI interaction is displayed in Test Review mode without any errors.