### PR TITLE
fix: reset the previous definition of the XML, to receive updated passage

### DIFF
--- a/src/qtiItem/helper/xincludeLoader.js
+++ b/src/qtiItem/helper/xincludeLoader.js
@@ -6,8 +6,11 @@ import Loader from 'taoQtiItem/qtiItem/core/Loader';
 function load(xinclude, baseUrl, callback) {
     const href = xinclude.attr('href');
     if (href && baseUrl) {
-        //require xml :
-        require([`text!${baseUrl}${href}`], function (stimulusXml) {
+        const fileUrl = `text!${baseUrl}${href}`;
+        // reset the previous definition of the XML, to recive updated passage
+        require.undef(fileUrl);
+        // require xml
+        require([fileUrl], function (stimulusXml) {
             const $wrapper = $.parseXML(stimulusXml);
             const $sampleXMLrootNode = $wrapper.children;
             const $stimulus = $('<include>').append($sampleXMLrootNode);

--- a/src/qtiItem/helper/xincludeLoader.js
+++ b/src/qtiItem/helper/xincludeLoader.js
@@ -7,7 +7,7 @@ function load(xinclude, baseUrl, callback) {
     const href = xinclude.attr('href');
     if (href && baseUrl) {
         const fileUrl = `text!${baseUrl}${href}`;
-        // reset the previous definition of the XML, to recive updated passage
+        // reset the previous definition of the XML, to receive updated passage
         require.undef(fileUrl);
         // require xml
         require([fileUrl], function (stimulusXml) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2028

**Problem:** XML is loaded only once for Items page
**Solution:** reset the previous definition of the XML, to receive updated passage

## How to test:

- Create a item with shared stimulus
- Open new tab with media, editing the shared stimuli, save
- Going back to the tab with item, closing the item by "mange items"
- Then clicking "authoring again"

**Actual:**  The shared stimuli change is not included
**Expected:** The item is updated with the new change in shared stimuli.

