### PR TITLE
fix/TR-4004 Add default state null for media interaction

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -219,7 +219,7 @@ function setResponse(interaction, response) {
         try {
             const maxPlays = parseInt(interaction.attr('maxPlays'), 10) || 0;
             const responseValues = pciResponse.unserialize(response, interaction);
-            const timesPlayed = parseInt(responseValues[0], 10);
+            const timesPlayed = parseInt(responseValues[0], 10) || 0;
             getContainer(interaction).data('timesPlayed', timesPlayed);
 
             if (interaction.mediaElement) {
@@ -265,6 +265,10 @@ function resetResponse(interaction) {
  * @returns {Object}
  */
 function getResponse(interaction) {
+    if (!getContainer(interaction).data('timesPlayed')) {
+        return { base: null };
+    }
+
     return pciResponse.serialize(_getRawResponse(interaction), interaction);
 }
 

--- a/test/qtiCommonRenderer/interactions/media/test.js
+++ b/test/qtiCommonRenderer/interactions/media/test.js
@@ -10,13 +10,20 @@ define([
     var isHeadless = /(PhantomJS|HeadlessChrome)/.test(navigator.userAgent);
     var videoSampleUrl = '/test/samples/json/media/sample.mp4';
     var audioSampleUrl = '/test/samples/json/media/sample.mp3';
+    var runner;
 
-    QUnit.module('Media Interaction');
+    QUnit.module('Media Interaction', {
+        beforeEach: function() {
+            runner = null;
+        },
+        afterEach: function() {
+            runner.clear();
+        }
+    });
 
     QUnit.test('video renders correctly', function(assert) {
         var ready = assert.async();
         var $container;
-        var runner;
 
         assert.expect(13);
 
@@ -25,7 +32,7 @@ define([
         assert.equal($container.length, 1, 'the item container exists');
         assert.equal($container.children().length, 0, 'the container has no children');
 
-        $container.one('playerrendered', function() {
+        $container.on('playerrendered', function() {
             //Check DOM
             assert.equal($container.children().length, 1, 'the container exists');
             assert.equal(
@@ -80,9 +87,10 @@ define([
                 'i1429259831305858',
                 'the .qti-item node has the right identifier'
             );
-            runner.clear();
 
-            ready();
+            setTimeout(function() {
+                ready();
+            }, 250);
         });
         runner = qtiItemRunner('qti', videoItemData)
             .on('error', function(e) {
@@ -102,7 +110,6 @@ define([
     QUnit.test('audio renders correctly', function(assert) {
         var ready = assert.async();
         var $container;
-        var runner;
 
         assert.expect(15);
 
@@ -176,8 +183,10 @@ define([
                 'i1429259831305858',
                 'the .qti-item node has the right identifier'
             );
-            runner.clear();
-            ready();
+
+            setTimeout(function() {
+                ready();
+            }, 250);
         });
 
         runner = qtiItemRunner('qti', audioItemData)
@@ -198,7 +207,6 @@ define([
     QUnit.test('get state', function(assert) {
         var ready = assert.async();
         var $container;
-        var runner;
 
         assert.expect(5);
 
@@ -208,11 +216,10 @@ define([
 
         $container.one('playerrendered', function() {
             var $mediaInteraction = $container.find('.qti-mediaInteraction');
-            var $play = $('.control [data-control=play]', $mediaInteraction);
-            var toState = setTimeout(function() {
+            var $play = $('.control [data-control=play]');
+            var afterPlayHandler = setTimeout(function() {
                 var state = runner.getState();
-                assert.ok(state.RESPONSE.player.position > 0, 'The player position has changed');
-                runner.clear();
+                assert.ok(state.RESPONSE.player.position === 0, 'The player position loaded from config');
                 ready();
             }, 1000);
 
@@ -224,17 +231,12 @@ define([
                 //so we just skip the test :
                 if ($('.mediaplayer', $mediaInteraction).hasClass('error')) {
                     assert.ok(true, 'Skipping');
-                    clearTimeout(toState);
-
+                    clearTimeout(afterPlayHandler);
                     ready();
-                } else {
-                    $play.click();
                 }
             }, 250);
         });
-        if (runner) {
-            runner.clear();
-        }
+
         runner = qtiItemRunner('qti', audioItemData)
             .on('init', function() {
                 var state = this.getState();
@@ -244,9 +246,7 @@ define([
                     {
                         RESPONSE: {
                             response: {
-                                base: {
-                                    integer: 0
-                                }
+                                base: null
                             },
                             player: {
                                 position: 0,
@@ -278,7 +278,6 @@ define([
         QUnit.test('set state', function(assert) {
             var ready = assert.async();
             var $container;
-            var runner;
 
             assert.expect(3);
 
@@ -290,7 +289,7 @@ define([
                 'The media interaction is not yet rendered'
             );
 
-            $container.on('playerrendered', function() {
+            $container.one('playerrendered', function() {
                 var $mediaInteraction = $container.find('.qti-mediaInteraction');
                 assert.equal($mediaInteraction.length, 1, 'The mediaInteraction is rendered');
                 if ($('.mediaplayer', $mediaInteraction).hasClass('error') || isHeadless) {
@@ -307,7 +306,6 @@ define([
                             assert.ok(state.RESPONSE.player.position > 0, 'The player position has changed');
                         }
                         $container.off('playerrendered');
-                        runner.clear();
                         ready();
                     }, 250);
                 }
@@ -318,9 +316,7 @@ define([
                     this.setState({
                         RESPONSE: {
                             response: {
-                                base: {
-                                    integer: 0
-                                }
+                                base: null
                             },
                             player: {
                                 position: 1.1,
@@ -343,11 +339,18 @@ define([
                 .init()
                 .render($container);
         });
-        QUnit.module('Visual Test');
+
+        QUnit.module('Visual Test', {
+            beforeEach: function() {
+                runner = null;
+            },
+            afterEach: function() {
+                runner.clear();
+            }
+        });
         QUnit.test('Display and play', function(assert) {
             var ready = assert.async();
             var $container;
-            var runner;
 
             assert.expect(4);
 

--- a/test/qtiCommonRenderer/interactions/media/test.js
+++ b/test/qtiCommonRenderer/interactions/media/test.js
@@ -10,20 +10,12 @@ define([
     var isHeadless = /(PhantomJS|HeadlessChrome)/.test(navigator.userAgent);
     var videoSampleUrl = '/test/samples/json/media/sample.mp4';
     var audioSampleUrl = '/test/samples/json/media/sample.mp3';
-    var runner;
 
-    QUnit.module('Media Interaction', {
-        beforeEach: function() {
-            runner = null;
-        },
-        afterEach: function() {
-            runner.clear();
-        }
-    });
-
+    QUnit.module('Media Interaction');
     QUnit.test('video renders correctly', function(assert) {
         var ready = assert.async();
         var $container;
+        var runner;
 
         assert.expect(13);
 
@@ -89,12 +81,14 @@ define([
             );
 
             setTimeout(function() {
+                runner.clear();
                 ready();
             }, 250);
         });
         runner = qtiItemRunner('qti', videoItemData)
             .on('error', function(e) {
                 assert.ok(false, e);
+                runner.clear();
                 ready();
             })
             .assets(function(url) {
@@ -110,6 +104,7 @@ define([
     QUnit.test('audio renders correctly', function(assert) {
         var ready = assert.async();
         var $container;
+        var runner;
 
         assert.expect(15);
 
@@ -185,6 +180,7 @@ define([
             );
 
             setTimeout(function() {
+                runner.clear();
                 ready();
             }, 250);
         });
@@ -192,6 +188,7 @@ define([
         runner = qtiItemRunner('qti', audioItemData)
             .on('error', function(e) {
                 assert.ok(false, e);
+                runner.clear();
                 ready();
             })
             .assets(function(url) {
@@ -207,6 +204,7 @@ define([
     QUnit.test('get state', function(assert) {
         var ready = assert.async();
         var $container;
+        var runner;
 
         assert.expect(5);
 
@@ -220,6 +218,7 @@ define([
             var afterPlayHandler = setTimeout(function() {
                 var state = runner.getState();
                 assert.ok(state.RESPONSE.player.position === 0, 'The player position loaded from config');
+                runner.clear();
                 ready();
             }, 1000);
 
@@ -232,6 +231,7 @@ define([
                 if ($('.mediaplayer', $mediaInteraction).hasClass('error')) {
                     assert.ok(true, 'Skipping');
                     clearTimeout(afterPlayHandler);
+                    runner.clear();
                     ready();
                 }
             }, 250);
@@ -260,6 +260,7 @@ define([
             })
             .on('error', function(err) {
                 assert.ok(false, err);
+                runner.clear();
                 ready();
             })
             .assets(function(url) {
@@ -278,6 +279,7 @@ define([
         QUnit.test('set state', function(assert) {
             var ready = assert.async();
             var $container;
+            var runner;
 
             assert.expect(3);
 
@@ -306,6 +308,7 @@ define([
                             assert.ok(state.RESPONSE.player.position > 0, 'The player position has changed');
                         }
                         $container.off('playerrendered');
+                        runner.clear();
                         ready();
                     }, 250);
                 }
@@ -328,6 +331,7 @@ define([
                 })
                 .on('error', function(err) {
                     assert.ok(false, err);
+                    runner.clear();
                     ready();
                 })
                 .assets(function(url) {
@@ -340,17 +344,11 @@ define([
                 .render($container);
         });
 
-        QUnit.module('Visual Test', {
-            beforeEach: function() {
-                runner = null;
-            },
-            afterEach: function() {
-                runner.clear();
-            }
-        });
+        QUnit.module('Visual Test');
         QUnit.test('Display and play', function(assert) {
             var ready = assert.async();
             var $container;
+            var runner;
 
             assert.expect(4);
 
@@ -368,6 +366,7 @@ define([
                 );
                 assert.equal($container.find('.qti-mediaInteraction video').length, 1, 'the interaction has element');
 
+                runner.clear();
                 ready();
             });
             runner = qtiItemRunner('qti', videoItemData)


### PR DESCRIPTION
PR template

Related to: [TR-4004](https://oat-sa.atlassian.net/browse/TR-4004)

**Description:**
Add null as the default(initial) value for media interaction to fix viewed and answered state

**Changes:**
*Changed `setResponse` and `getResponse` to fix the state for media interaction on runtime.
*Update Unit-test with removing play action, not necessary to the test case, and add a timeout to render to prevent triggering error after test execution

**How to check:**
* Create items with media interaction and choices interaction.
* Add multiple (3+) previously created items to the test 
* Start the test and play media once to set the item to answer state
* Move to the next one and do not interact click next
* Observe that one item has a circle icon(answered) another has an eye icon (viewed)
* Refresh the page, observe item states should be the same