### PR TITLE
fix: resize Media interaction

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -79,7 +79,9 @@ function render(interaction) {
          * @param {jQueryElement} $container   - container element to adapt
          */
         const resize = _.debounce(() => {
-            if (interaction.mediaElement) {
+            // only resize when width in px
+            // new version has width in %
+            if (interaction.mediaElement && media.attr('width') && !/%/.test(media.attr('width'))) {
                 const height = $container.find('.media-container').height();
                 const width = $container.find('.media-container').width();
 
@@ -110,16 +112,13 @@ function render(interaction) {
                     renderTo: $('.media-container', $container)
                 })
                     .on('render', () => {
-                        // to support old sizes in px
-                        if (media.attr('width') && !/%/.test(media.attr('width'))) {
-                            resize();
+                        resize();
 
-                            $(window)
-                                .off('resize.mediaInteraction')
-                                .on('resize.mediaInteraction', resize);
+                        $(window)
+                            .off('resize.mediaInteraction')
+                            .on('resize.mediaInteraction', resize);
 
-                            $item.off('resize.gridEdit').on('resize.gridEdit', resize);
-                        }
+                        $item.off('resize.gridEdit').on('resize.gridEdit', resize);
                         /**
                          * @event playerrendered
                          */

--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -81,7 +81,8 @@ function render(interaction) {
         const resize = _.debounce(() => {
             // only resize when width in px
             // new version has width in %
-            if (interaction.mediaElement && media.attr('width') && !/%/.test(media.attr('width'))) {
+            const  currentWidth = media.attr('width');
+            if (interaction.mediaElement && currentWidth && !currentWidth.includes('%')) {
                 const height = $container.find('.media-container').height();
                 const width = $container.find('.media-container').width();
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2178

Regression after fix:
https://github.com/oat-sa/tao-item-runner-qti-fe/pull/262/files#diff-903b0c826874b1e9917b94ae77a002c935309dcab424c432a854d651e4ba339bR138-R140

**Solution:** move condition (if media interaction in old format == width in `px`, not in `%`) to `resize` function 

## Steps to reproduce: 

- Click the Items tab, create a new Item and click its "Authoring" button
- Drag and Drop a Media Interaction on the canvas
- Add the video file from Resource manager 
- Modify the Size value of Media Player and click outside the interaction area
- Observe the Media Interaction

**Actual result:** Media player adjusts to the size of Media Interaction container, video is displayed in the center on the black background
**Expected result:** Media Player can be resized independently from the size of the media interaction container