### PR TITLE
Fix/TR-3995/Max words restriction can be exceeded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,9 +499,8 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.19.1.tgz",
-            "integrity": "sha512-czVMobjxDQlUYQvVkAhI0k07Zt47hdhhuibKHtfyob0qHT9DMJMkI61J9gT7LfA9spwMDsYOCoF+tFc1jQNJ/w==",
+            "version": "github:oat-sa/tao-core-sdk-fe#4057299d42d8c5f0ec27e0e0b786d1a39e691b4f",
+            "from": "github:oat-sa/tao-core-sdk-fe#fix/TR-3995/max-words-restriction-can-be-exceeded",
             "dev": true,
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,8 +499,8 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "github:oat-sa/tao-core-sdk-fe#4057299d42d8c5f0ec27e0e0b786d1a39e691b4f",
-            "from": "github:oat-sa/tao-core-sdk-fe#fix/TR-3995/max-words-restriction-can-be-exceeded",
+            "version": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#4057299d42d8c5f0ec27e0e0b786d1a39e691b4f",
+            "from": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#fix/TR-3995/max-words-restriction-can-be-exceeded",
             "dev": true,
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",
@@ -2398,7 +2398,7 @@
         "idb-wrapper": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.0.tgz",
-            "integrity": "sha1-Cn+yxw4OF3+RGOZHPGdTVrXmKD4=",
+            "integrity": "sha512-X9Xgu7/c/HvMMxZ+TRJQ95q8Cv7QbEBz/3+SAgYSP6HpqEJyj3cRFIXRTN1mtSZxbdKbfAXBpxwi+VSJnfaexg==",
             "dev": true
         },
         "ieee754": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,8 +499,9 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#4057299d42d8c5f0ec27e0e0b786d1a39e691b4f",
-            "from": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#fix/TR-3995/max-words-restriction-can-be-exceeded",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.19.2.tgz",
+            "integrity": "sha512-qV0tScu/d1DdVVCX8NPb90RHPxxHVy/ydHBrS6vshM9+2fV8ytf8PrSCmQOEiw4CoBbg7fDuuIQAsUQtA0tsKw==",
             "dev": true,
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.4.4",
-        "@oat-sa/tao-core-sdk": "1.19.1",
+        "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#fix/TR-3995/max-words-restriction-can-be-exceeded",
         "@oat-sa/tao-core-shared-libs": "1.0.4",
         "@oat-sa/tao-core-ui": "1.45.0",
         "@oat-sa/tao-item-runner": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.4.4",
-        "@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe#fix/TR-3995/max-words-restriction-can-be-exceeded",
+        "@oat-sa/tao-core-sdk": "1.19.2",
         "@oat-sa/tao-core-shared-libs": "1.0.4",
         "@oat-sa/tao-core-ui": "1.45.0",
         "@oat-sa/tao-item-runner": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.4.4",
-        "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#fix/TR-3995/max-words-restriction-can-be-exceeded",
+        "@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe#fix/TR-3995/max-words-restriction-can-be-exceeded",
         "@oat-sa/tao-core-shared-libs": "1.0.4",
         "@oat-sa/tao-core-ui": "1.45.0",
         "@oat-sa/tao-item-runner": "^0.3.1",

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -553,9 +553,9 @@ function inputLimiter(interaction) {
                 }
 
                 // limit by word or character count if required
-                if (!_.isNull(maxWords)) {
+                if (maxWords) {
                     newValue = strLimiter.limitByWordCount(newValue, maxWords - this.getWordsCount());
-                } else if (!_.isNull(maxLength)) {
+                } else if (maxLength) {
                     newValue = strLimiter.limitByCharCount(newValue, maxLength - this.getCharsCount());
                 }
 

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -369,8 +369,8 @@ function inputLimiter(interaction) {
         $maxWordsCounter = $('.count-max-words', $container);
 
         if (patternMask !== '') {
-            maxWords = patternMaskHelper.parsePattern(patternMask, 'words');
-            maxLength = patternMaskHelper.parsePattern(patternMask, 'chars');
+            maxWords = parseInt(patternMaskHelper.parsePattern(patternMask, 'words'), 10);
+            maxLength = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10);
             maxWords = _.isNaN(maxWords) ? 0 : maxWords;
             maxLength = _.isNaN(maxLength) ? 0 : maxLength;
             if (!maxLength && !maxWords) {
@@ -494,7 +494,7 @@ function inputLimiter(interaction) {
                 const isCke = _getFormat(interaction) === 'xhtml';
                 if (
                     !_.contains(ignoreKeyCodes, keyCode) &&
-                    ((maxWords && this.getWordsCount() >= maxWords && _.contains(triggerKeyCodes, keyCode)) ||
+                    ((maxWords && this.getWordsCount() >= maxWords && !_.contains(triggerKeyCodes, keyCode)) ||
                         (maxLength && this.getCharsCount() >= maxLength))
                 ) {
                     if (e.cancel) {
@@ -504,7 +504,7 @@ function inputLimiter(interaction) {
                         e.stopImmediatePropagation();
                     }
 
-                    if (this.getCharsCount() > maxLength && maxLength !== null) {
+                    if (maxLength && this.getCharsCount() > maxLength) {
                         if (!isCke) {
                             const currentValue = $textarea[0].value;
                             $textarea[0].value = currentValue.substring(0, maxLength);
@@ -536,8 +536,8 @@ function inputLimiter(interaction) {
                     newValue = e.originalEvent.clipboardData
                         ? e.originalEvent.clipboardData.getData('text')
                         : e.originalEvent.dataTransfer.getData('text') ||
-                        e.originalEvent.dataTransfer.getData('text/plain') ||
-                        '';
+                          e.originalEvent.dataTransfer.getData('text/plain') ||
+                          '';
                 }
 
                 // prevent insertion of non-limited data
@@ -938,7 +938,9 @@ function getData(interaction, data) {
     const maxWords = parseInt(patternMaskHelper.parsePattern(pattern, 'words'), 10);
     const maxLength = parseInt(patternMaskHelper.parsePattern(pattern, 'chars'), 10);
     const expectedLines = parseInt(interaction.attr('expectedLines'), 10);
-    const expectedLength = !isNaN(expectedLines) ? expectedLines * 72 : parseInt(interaction.attr('expectedLength'), 10);
+    const expectedLength = !isNaN(expectedLines)
+        ? expectedLines * 72
+        : parseInt(interaction.attr('expectedLength'), 10);
 
     // Build DOM placeholders, this is needed to properly assemble the constraint hints
     // The interaction will later rely on this to bind the values
@@ -957,7 +959,7 @@ function getData(interaction, data) {
         constraintHints: {
             expectedLength: __('%s of %s characters recommended.', countChars, countExpectedLength),
             maxLength: __('%s of %s characters maximum.', countChars, countMaxLength),
-            maxWords: __('%s of %s words maximum.', countWords, countMaxWords),
+            maxWords: __('%s of %s words maximum.', countWords, countMaxWords)
         }
     });
 }

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -428,7 +428,7 @@ function inputLimiter(interaction) {
                 1114202, // Ctrl + z
                 1114200 // Ctrl + x
             ];
-            const triggerKeyCodes = [
+            const spaceKeyCodes = [
                 32, // space
                 13, // enter
                 2228237 // shift + enter in ckEditor
@@ -557,7 +557,7 @@ function inputLimiter(interaction) {
                     //   AND the selection is empty,
                     //   AND the keystroke is not from the list of accepted codes,
                     //   AND the keystroke is not a space
-                    if ((!emptyOrSpace(left) && !emptyOrSpace(right) && !hasSpace(middle) && (keyCode === 13 || keyCode === 32)) ||
+                    if ((!emptyOrSpace(left) && !emptyOrSpace(right) && !hasSpace(middle) && _.contains(spaceKeyCodes, keyCode)) ||
                         (emptyOrSpace(left) && emptyOrSpace(right) && !middle && !acceptKeyCode(keyCode) && keyCode !== 32)) {
                         return cancelEvent(e);
                     }

--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -20,6 +20,8 @@
 /**
  * @author Ansul Sharma <ansultaotesting.com>
  */
+import $ from 'jquery';
+import _ from 'lodash';
 import template from 'taoQtiItem/reviewRenderer/tpl/interactions/extendedTextInteraction';
 import patternMaskHelper from 'taoQtiItem/qtiCommonRenderer/helpers/patternMask';
 import extendedTextInteraction from 'taoQtiItem/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction';
@@ -157,8 +159,8 @@ const inputLimiter = interaction => {
         $maxWordsCounter = $('.count-max-words', $container);
 
         if (patternMask !== '') {
-            maxWords = patternMaskHelper.parsePattern(patternMask, 'words');
-            maxLength = patternMaskHelper.parsePattern(patternMask, 'chars');
+            maxWords = parseInt(patternMaskHelper.parsePattern(patternMask, 'words'), 10);
+            maxLength = parseInt(patternMaskHelper.parsePattern(patternMask, 'chars'), 10);
             maxWords = _.isNaN(maxWords) ? 0 : maxWords;
             maxLength = _.isNaN(maxLength) ? 0 : maxLength;
             if (!maxLength && !maxWords) {


### PR DESCRIPTION
3/4

Related to: https://oat-sa.atlassian.net/browse/TR-3995

Requires: 
 - [x] https://github.com/oat-sa/tao-core-sdk-fe/pull/145
 - [x] update the `package.json` file once the companion PR has been merged

The extended text interaction was allowing typing more words than the allowed constraint.
This was due to some wrong conditions in the keystroke handler and a missing typecast when reading the constraint properties.

How to test:
- create a test having extended text interactions with a constraint for the max words and for the max length (a test sample is attached to the ticket).
- publish the test, then take it
- type some text in the extended text interaction, then copy it and paste it until the limit is reached.
- try to exhaust the limit by typing more words
- add a new line by pressing the enter key
- try again to exhaust the limit by typing more words

Without the fix, the limit can be overflown.
With the fix, we cannot overflow the limit.