### PR TITLE
fix/AUT-2191/extendedtext-toggle-text-counter

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -24,6 +24,7 @@
 import $ from 'jquery';
 import _ from 'lodash';
 import __ from 'i18n';
+import features from 'services/features';
 import strLimiter from 'util/strLimiter';
 import template from 'taoQtiItem/qtiCommonRenderer/tpl/interactions/extendedTextInteraction';
 import countTpl from 'taoQtiItem/qtiCommonRenderer/tpl/interactions/constraints/count';
@@ -83,6 +84,11 @@ const render = function render(interaction) {
                 $el.attr('placeholder', placeholderText);
             }
             if (_getFormat(interaction) === 'xhtml') {
+                
+                if(!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints') && !features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations')) {
+                    $container.find('.text-counter').hide();
+                }
+
                 _styleUpdater = function () {
                     let qtiItemStyle, $editorBody, qtiItem;
 

--- a/test/qtiCommonRenderer/interactions/extendedText/test.html
+++ b/test/qtiCommonRenderer/interactions/extendedText/test.html
@@ -7,6 +7,13 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
+                    define('services/features', function() {
+                        return {
+                            isVisible: function() {
+                                return true;
+                            }
+                        }
+                    });
                     require(['taoQtiItem/test/qtiCommonRenderer/interactions/extendedText/test'], function() {
                         QUnit.start();
                         QUnit.config.reorder = false;

--- a/test/reviewRenderer/interactions/extendedText/test.html
+++ b/test/reviewRenderer/interactions/extendedText/test.html
@@ -7,6 +7,13 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function () {
                 require(['qunitEnv'], function () {
+                    define('services/features', function() {
+                        return {
+                            isVisible: function() {
+                                return true;
+                            }
+                        }
+                    });
                     require(['taoQtiItem/test/reviewRenderer/interactions/extendedText/test'], function () {
                         QUnit.start();
                         QUnit.config.reorder = false;


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-2191

### Description

When switching format in extendedText interaction the textCount panel related to constraints/recommendations should be toggled if related feature is hidden from UI by configuration

### How to test

 - Kitchen : https://test-hidefeatures.playground.kitchen.it.taocloud.org/

-  Locally : should be tested along with https://github.com/oat-sa/extension-tao-itemqti/pull/2130
Disable xhtml constraints & recommendations in UI, use `config/tao/client_lib_config_registry.conf.php`
set 
```
                'taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints' => 'hide',
                'taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations' => 'hide',
``` 
in services/features section
Edit extendedText intearction, switch between PlainText and RichText modes, see the textCounter is toggled accordingly