### PR TITLE
fix/OATSD-1870_fix-words-counter-for-xhtml-extended-text

### DIFF
--- a/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -183,9 +183,15 @@ const inputLimiter = interaction => {
          * @return {Number} number of words
          */
         getWordsCount: () => {
-            const value = _getTextContainerValue(interaction) || '';
+            let value = _getTextContainerValue(interaction) || '';
             if (_.isEmpty(value)) {
                 return 0;
+            }
+            // convert it to text
+            if (_getFormat(interaction) === 'xhtml') {
+                const div = document.createElement('div');
+                div.innerHTML = value;
+                value = div.textContent || div.innerText || '';
             }
             // leading and trailing white space don't qualify as words
             return value.trim().replace(/\s+/gi, ' ').split(' ').length;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/OATSD-1870.

Convert XHTML content to text before count words. I used the same approach that was working for character counting.

Deployed to http://playground.kitchen.it.taocloud.org/?p=test-os1870_delivery.git;a=summary

Test:
- Take a test with Extended Text Interaction
- Check its review mode in Result page.
- The original problem was with 4 spaces, where the result was ` &nbsp; &nbsp;`, that counted multiple words.