### PR TITLE
feature/AUT-2190/allow-elimination-toggle

### DIFF
--- a/environment/config.js
+++ b/environment/config.js
@@ -97,4 +97,11 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
     }));
     define('taoQtiItem/portableElementRegistry/provider/sideLoadingProviderFactory', [], () => {});
     define('taoQtiItem/portableElementRegistry/assetManager/portableAssetStrategy', [], () => {});
+    define('services/features', function() {
+        return {
+            isVisible: function() {
+                return true;
+            }
+        }
+    });
 });

--- a/src/qtiCommonRenderer/renderers/choices/SimpleChoice.ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/choices/SimpleChoice.ChoiceInteraction.js
@@ -22,12 +22,14 @@
  */
 import tpl from 'taoQtiItem/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
+import features from 'services/features';
 
 export default {
     qtiClass: 'simpleChoice.choiceInteraction',
     getContainer: containerHelper.get,
     getData: function(choice, data) {
         data.unique = parseInt(data.interaction.attributes.maxChoices) === 1;
+        data.allowElimination = features.isVisible('taoQtiItem/creator/interaction/choice/property/allowElimination');
         return data;
     },
     template: tpl

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -30,6 +30,7 @@ import instructionMgr from 'taoQtiItem/qtiCommonRenderer/helpers/instructions/in
 import pciResponse from 'taoQtiItem/qtiCommonRenderer/helpers/PciResponse';
 import sizeAdapter from 'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter';
 import adaptSize from 'util/adaptSize';
+import features from 'services/features';
 
 const KEY_CODE_SPACE = 32;
 const KEY_CODE_ENTER = 13;
@@ -392,7 +393,8 @@ const getCustomData = function getCustomData(interaction, data) {
     return _.merge(data || {}, {
         horizontal: interaction.attr('orientation') === 'horizontal',
         listStyle: listStyles.pop(),
-        eliminable: isEliminable(interaction)
+        eliminable: isEliminable(interaction),
+        allowEliminationVisible: features.isVisible('taoQtiItem/creator/interaction/choice/property/allowElimination')
     });
 };
 

--- a/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/choices/simpleChoice.choiceInteraction.tpl
@@ -29,7 +29,9 @@
             </div>
         </div>
     </div>
+    {{#if allowElimination}}
     <label data-eliminable="container" data-label="{{__ "Eliminate"}}">
         <span data-eliminable="trigger" class="icon-checkbox"></span>
     </label>
+    {{/if}}
 </li>

--- a/src/qtiCommonRenderer/tpl/interactions/choiceInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/choiceInteraction.tpl
@@ -1,6 +1,6 @@
 <div
   {{#if attributes.id}}id="{{attributes.id}}"{{/if}}
-  class="qti-interaction qti-blockInteraction qti-choiceInteraction{{#if attributes.class}} {{attributes.class}}{{/if}}"
+  class="qti-interaction qti-blockInteraction qti-choiceInteraction{{#if attributes.class}} {{attributes.class}}{{/if}}{{#if allowEliminationVisible}} allow-elimination-visible{{/if}}"
   data-serial="{{serial}}"
   data-qti-class="choiceInteraction"
   {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}

--- a/test/qtiCommonRenderer/interactions/choice/test.html
+++ b/test/qtiCommonRenderer/interactions/choice/test.html
@@ -7,6 +7,13 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
+                    define('services/features', function() {
+                        return {
+                            isVisible: function() {
+                                return true;
+                            }
+                        }
+                    });
                     require(['taoQtiItem/test/qtiCommonRenderer/interactions/choice/test'], function() {
                         QUnit.config.reorder = false;
                         QUnit.start();

--- a/test/qtiCommonRenderer/interactions/choice/test.html
+++ b/test/qtiCommonRenderer/interactions/choice/test.html
@@ -7,13 +7,6 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
-                    define('services/features', function() {
-                        return {
-                            isVisible: function() {
-                                return true;
-                            }
-                        }
-                    });
                     require(['taoQtiItem/test/qtiCommonRenderer/interactions/choice/test'], function() {
                         QUnit.config.reorder = false;
                         QUnit.start();

--- a/test/qtiCommonRenderer/interactions/extendedText/test.html
+++ b/test/qtiCommonRenderer/interactions/extendedText/test.html
@@ -7,13 +7,6 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
-                    define('services/features', function() {
-                        return {
-                            isVisible: function() {
-                                return true;
-                            }
-                        }
-                    });
                     require(['taoQtiItem/test/qtiCommonRenderer/interactions/extendedText/test'], function() {
                         QUnit.start();
                         QUnit.config.reorder = false;

--- a/test/reviewRenderer/interactions/extendedText/test.html
+++ b/test/reviewRenderer/interactions/extendedText/test.html
@@ -7,13 +7,6 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function () {
                 require(['qunitEnv'], function () {
-                    define('services/features', function() {
-                        return {
-                            isVisible: function() {
-                                return true;
-                            }
-                        }
-                    });
                     require(['taoQtiItem/test/reviewRenderer/interactions/extendedText/test'], function () {
                         QUnit.start();
                         QUnit.config.reorder = false;


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-2190

### Description 

Feature visibility service llows to configure authoring interface to hide unsupported features for client
Choice interaction renders the elimination checkboxes if allowElimination option is shown and on. This PR hides these checkboxes if allowElimination is hidden

### How to test

 - unit tests
 - with local backend, setup apropriate key in `config/tao/client_lib_config_registry.conf.php`
 
 ```
'services/features' => array(
            'visibility' => array(
                'taoQtiItem/creator/interaction/choice/property/allowElimination' => 'hide',
```