### PR TITLE
fix: toggle limiter based on constraints visibility

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -41,6 +41,9 @@ import loggerFactory from 'core/logger';
  */
 const logger = loggerFactory('taoQtiItem/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js');
 
+const hideXhtmlConstraints = !features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints');
+const hideXhtmlRecommendations = !features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations');
+
 /**
  * Init rendering, called after template injected into the DOM
  * All options are listed in the QTI v2.1 information model:
@@ -84,9 +87,13 @@ const render = function render(interaction) {
                 $el.attr('placeholder', placeholderText);
             }
             if (_getFormat(interaction) === 'xhtml') {
-                
-                if(!features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints') && !features.isVisible('taoQtiItem/creator/interaction/extendedText/property/xhtmlRecommendations')) {
+
+                if(hideXhtmlConstraints && hideXhtmlRecommendations) {
                     $container.find('.text-counter').hide();
+                }
+
+                if(hideXhtmlConstraints) {
+                    limiter.enabled = false;
                 }
 
                 _styleUpdater = function () {


### PR DESCRIPTION
releted to https://oat-sa.atlassian.net/browse/AUT-2191

### Description 

The limiter needs to be eliminated from item preview if constraints option is hidden from UI
See comment:
https://oat-sa.atlassian.net/browse/AUT-2191?focusedCommentId=186649

### How to test

Enable  Max Length constraint for extended text interaction, save it. Hide constraints feature from UI

`config/tao/client_lib_config_registry.conf.php` :

```
'services/features' => array(
            'visibility' => array(
                'taoQtiItem/creator/interaction/extendedText/property/xhtmlConstraints' => 'hide',
```

Reload item and preview. Text input should not be limited