### PR TITLE
chore: update tao-core-ui to 1.22.10-1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,9 +195,9 @@
             "dev": true
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.1.tgz",
-            "integrity": "sha512-djkyWkY9FNQW5O+QZzVfNdHpMC1iNNp2wXiybPl9NrVpDE6OfW4T4EeS1trsjoGnUXK2RiedplGraPBXRYcBeA==",
+            "version": "1.22.10-1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.10-1.tgz",
+            "integrity": "sha512-Fi4jzmxQThbtO1kPx4nB9pgTV4pn3HQBzVh//kCb39pAsNWOYW+y+u7VKfUpIyIDChC2vkbB8Z4H0NEZZD3MwA==",
             "dev": true
         },
         "@oat-sa/tao-item-runner": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@oat-sa/tao-core-libs": "^0.4.3",
         "@oat-sa/tao-core-sdk": "^1.8.1",
         "@oat-sa/tao-core-shared-libs": "^0.1.0",
-        "@oat-sa/tao-core-ui": "^1.22.1",
+        "@oat-sa/tao-core-ui": "^1.22.10-1",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",
         "async": "^0.2.10",


### PR DESCRIPTION
# Pull request summary

Related to [OATSD-1881](https://oat-sa.atlassian.net/browse/OATSD-1881).

Updated `@oat-sa/tao-core-ui` dependency to 1.22.10-1 including the fix.