### PR TITLE
fix/MS-2245_portable-element-image-pattern

### DIFF
--- a/src/qtiCommonRenderer/helpers/PortableElement.js
+++ b/src/qtiCommonRenderer/helpers/PortableElement.js
@@ -13,14 +13,14 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA ;
  */
 
 /**
  * Portable element helper
  */
 
-var imgSrcPattern = /(<img[^>]*src=["'])([^"']+)(["'])/gi;
+var imgSrcPattern = /(<img[^>]*\ssrc=["'])([^"']+)(["'])/gi;
 
 /**
  * Replace all identified relative media urls by the absolute one.


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/MS-2245

- Fix `imageSrcPattern`, because it was matching to `data-src` as well

Test:
- Open https://regex101.com/
- Select javascript format
- Insert new pattern: `(<img[^>]*\ssrc=["'])([^"']+)(["'])`
- Insert this example text and play with it: `<img src="resolvable.jpg" data-src="justdata.jpg" />`