### PR TITLE
fix/MS-2245_portable-element-review-renderer

### DIFF
--- a/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -35,7 +35,7 @@ const getData = function (customInteraction, data) {
 
     //remove ns + fix media file path
     markup = util.removeMarkupNamespaces(markup);
-    markup = PortableElement.fixMarkupMediaSources(markup, this);
+    markup = PortableElement.fixMarkupMediaSources(markup, customInteraction.renderer);
 
     return Object.assign({}, data, { markup, isInteractionDisabled });
 };


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/MS-2245

- Use correct renderer reference instead of `this` what is `undefined`

Test:
- Bulid code and check `dist/reviewRenderer/renderers/interactions/PortableCustomInteraction.js` and search for `fixMarkupMediaSources`. Second parameter should not be `undefined` anymore.

or

- Have a PCI that have images inside and open review mode