### PR TITLE
Fix/aut 2270/mathentryinteraction math duplicated

### DIFF
--- a/src/qtiCommonRenderer/renderers/Math.js
+++ b/src/qtiCommonRenderer/renderers/Math.js
@@ -23,7 +23,6 @@
  * @author Sam Sipasseuth <sam@taotesting.com>
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-import _ from 'lodash';
 import tpl from 'taoQtiItem/qtiCommonRenderer/tpl/math';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import MathJax from 'mathJax';

--- a/src/qtiCommonRenderer/renderers/Math.js
+++ b/src/qtiCommonRenderer/renderers/Math.js
@@ -40,23 +40,15 @@ export default {
     getContainer: containerHelper.get,
     render: function render(math) {
         return new Promise(function (resolve) {
-            //for performance it's better to run `MathJax Typeset` at once for all math on the page;
-            //but if you do it when there are already MathJax-rendered elements on the page,
-            //  in some cases MathJax won't recognize that and produce duplicated output;
-            //so we run `Typeset` for all elements if none of them are rendered yet (test-runner item load in delivery),
-            //but only for current element otherwise (working in Authoring)
             const $self = containerHelper.get(math);
-            const $item = $self.closest('.qti-item');
-            const itemHasRenderedMath = $item.find('.MathJax[data-mathml]').length > 0;
-            const $mathjaxScope = itemHasRenderedMath ? $self : $item;
             if (typeof MathJax !== 'undefined' && MathJax) {
                 //MathJax needs to be exported globally to integrate with tools like TTS, it's weird...
                 if (!window.MathJax) {
                     window.MathJax = MathJax;
                 }
                 //defer execution fix some rendering issue in chrome
-                if ($mathjaxScope.length) {
-                    MathJax.Hub.Queue(['Typeset', MathJax.Hub, $mathjaxScope[0]]);
+                if ($self.length) {
+                    MathJax.Hub.Queue(['Typeset', MathJax.Hub, $self[0]]);
                     MathJax.Hub.Queue(resolve);
                 } else {
                     resolve();


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/AUT-2270

Use with https://github.com/oat-sa/extension-tao-itemqti/pull/2171 

For each individual math element, MathJax  [Typeset](https://docs.mathjax.org/en/v2.0-latest/typeset.html#modifying-math-on-the-page) runs on all `.qti-item`, so if there are several elements, they are "typeset" several times. It's ok in delivery, but not in Authoring of `MathEntryInteraction` prompt (Probably html elements are cloned by Authoring, and [MathJax](https://github.com/mathjax/MathJax/blob/2.7.5/unpacked/MathJax.js#L2070) which seems to keep data about what was rendered in its objects doesn't recognize them as already processed)


**HISTORY:**
_(see ticket comments)_
1) First scope of "typeset" was `parent()` (_why parent, not self? for performance too?.._):
   https://github.com/oat-sa/tao-item-runner-qti-fe/pull/37/files
2) Then it was changed to `.qti-item` + `$item.data('mathInitialized')` condition to run it once was added, for performance improvement
    https://github.com/oat-sa/tao-item-runner-qti-fe/pull/37/files
    https://oat-sa.atlassian.net/browse/OATSD-187?focusedCommentId=67025
3) Then `$item.data('mathInitialized')` condition was removed (_did performance improvement remain?.._):
    https://github.com/oat-sa/tao-item-runner-qti-fe/pull/193/files
4) Here I changed scope to 'self' (single math expression).

I tried to measure 2) & 3) & 4) and didn't see any definite difference between them. Does this performance improvement still have effect?.. 2.5 years passed since then. I used an item with 30 complex math expressions, Chrome with and without CPU throttle, compared duration of `this._item.postRender(options)` in item-runner `qti.js`, and Scripting/Rendering/Painting time in DevTools Performance 


**ALTERNATIVE VERSION:**
https://github.com/oat-sa/tao-item-runner-qti-fe/pull/303/commits/6ff5e9f6e92181354de0ff43aa5f6c7fec0d5043 : It will keep _previous_ behavior in _delivery_ test-runner, but will have _new_ behavior in _Authoring_. 
Since it keeps previous behavior, it may be safer - what if there really was a performance benefit in it?.. :confused:
Please let me know if you prefer it.
