### PR TITLE
Fix/tr 4451/inlinechoice empty label text

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -58,7 +58,7 @@ var render = function(interaction, options) {
     _.extend(opts, options);
 
     if (opts.allowEmpty && !required) {
-        $container.find('option[value=' + _emptyValue + ']').text('--- ' + __('leave empty') + ' ---');
+        $container.find('option[value=' + _emptyValue + ']').text(__('--- leave empty ---') || '--- ' + __('leave empty') + ' ---');
     } else {
         $container.find('option[value=' + _emptyValue + ']').remove();
     }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4451

I need to override `--- leave empty ---` text for empty option from customer extension.

1) I think we can't simply remove old `__('leave empty')` key without possibly losing existing translations? Or is there a way to find all places where it's translated and change them?
2) Otherwise is there a way to pass a `emptyLabelText` option from customer extension to interaction? Like in Solar we use `propertyOverride` in `tenants.json`.