### PR TITLE
fix: do not remove SCORE and MAXSCORE from outcomeDeclaration

### DIFF
--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -124,13 +124,20 @@ export default {
 
             }
         }
-        
+
         //handle special case, when responseProcessing is set to none and MAXSCORE is setup manually
         //remove MAXSCORE if externalProcessing is not set up:
         maxScoreOutcome = item.getOutcomeDeclaration('MAXSCORE');
-        if(maxScoreOutcome && !(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored)) {
-            item.removeOutcome('MAXSCORE');
-        }
+        if(maxScoreOutcome && item.responseProcessing && item.responseProcessing.processingType !== 'templateDriven') {
+            if(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored) {
+                if(_.isUndefined(maxScoreOutcome.defaultValue)) {
+                    maxScoreOutcome.setDefaultValue(1)
+                }
+            } else {
+                item.removeOutcome('MAXSCORE');
+            }
+        } 
+        
         
     },
 

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -121,25 +121,16 @@ export default {
                     maxScoreOutcome.buildIdentifier('MAXSCORE', false);
                 }
                 maxScoreOutcome.setDefaultValue(maxScore);
-
             }
 
-            //handle special case, when responseProcessing is set to none and MAXSCORE is setup manually
-            //remove MAXSCORE if externalProcessing is not set up:
-            maxScoreOutcome = item.getOutcomeDeclaration('MAXSCORE');
-            if(maxScoreOutcome) {
-                var interactions = item.responseProcessing.getRootElement().getInteractions();
-                if(interactions.length === 1) {
-                    const response = interactions[0].getResponseDeclaration();
-                    if(response.template === 'no_response_processing'){
-                        if(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored) {
-                            if(_.isUndefined(maxScoreOutcome.defaultValue)) {
-                                maxScoreOutcome.setDefaultValue(1);
-                            }
-                        } else {
-                            item.removeOutcome('MAXSCORE');
-                        }
+            //handle special case when MAXSCORE is set up manually for some interaction like ExtendedText
+            if(hasInvalidInteraction && maxScoreOutcome) {
+                if(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored) {
+                    if(_.isUndefined(maxScoreOutcome.defaultValue)) {
+                        maxScoreOutcome.setDefaultValue(1);
                     }
+                } else {
+                    item.removeOutcome('MAXSCORE');
                 }
             }
         } 

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -121,9 +121,6 @@ export default {
                     maxScoreOutcome.buildIdentifier('MAXSCORE', false);
                 }
                 maxScoreOutcome.setDefaultValue(maxScore);
-            } else {
-                //remove MAXSCORE:
-                item.removeOutcome('MAXSCORE');
             }
         }
     },

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -121,8 +121,17 @@ export default {
                     maxScoreOutcome.buildIdentifier('MAXSCORE', false);
                 }
                 maxScoreOutcome.setDefaultValue(maxScore);
+
             }
         }
+        
+        //handle special case, when responseProcessing is set to none and MAXSCORE is setup manually
+        //remove MAXSCORE if externalProcessing is not set up:
+        maxScoreOutcome = item.getOutcomeDeclaration('MAXSCORE');
+        if(maxScoreOutcome && !(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored)) {
+            item.removeOutcome('MAXSCORE');
+        }
+        
     },
 
     /**

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -134,17 +134,15 @@ export default {
                     if(response.template === 'no_response_processing'){
                         if(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored) {
                             if(_.isUndefined(maxScoreOutcome.defaultValue)) {
-                                maxScoreOutcome.setDefaultValue(1)
+                                maxScoreOutcome.setDefaultValue(1);
                             }
                         } else {
                             item.removeOutcome('MAXSCORE');
                         }
                     }
                 }
-
             }
         } 
-                
     },
 
     /**
@@ -185,7 +183,6 @@ export default {
             requiredChoiceCount,
             totalAnswerableResponse,
             sortedMapEntries,
-            i,
             missingMapsCount;
 
         options = _.defaults(options || {}, { maxChoices: 0, minChoices: 0 });

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -133,7 +133,7 @@ export default {
                     item.removeOutcome('MAXSCORE');
                 }
             }
-        } 
+        }
     },
 
     /**

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -107,8 +107,8 @@ export default {
                 }, maxScore);
             }
 
+            maxScoreOutcome = item.getOutcomeDeclaration('MAXSCORE');
             if (!hasInvalidInteraction || customOutcomes.size()) {
-                maxScoreOutcome = item.getOutcomeDeclaration('MAXSCORE');
                 if (!maxScoreOutcome) {
                     //add new outcome
                     maxScoreOutcome = new OutcomeDeclaration({

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -123,22 +123,28 @@ export default {
                 maxScoreOutcome.setDefaultValue(maxScore);
 
             }
-        }
 
-        //handle special case, when responseProcessing is set to none and MAXSCORE is setup manually
-        //remove MAXSCORE if externalProcessing is not set up:
-        maxScoreOutcome = item.getOutcomeDeclaration('MAXSCORE');
-        if(maxScoreOutcome && item.responseProcessing && item.responseProcessing.processingType !== 'templateDriven') {
-            if(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored) {
-                if(_.isUndefined(maxScoreOutcome.defaultValue)) {
-                    maxScoreOutcome.setDefaultValue(1)
+            //handle special case, when responseProcessing is set to none and MAXSCORE is setup manually
+            //remove MAXSCORE if externalProcessing is not set up:
+            maxScoreOutcome = item.getOutcomeDeclaration('MAXSCORE');
+            if(maxScoreOutcome) {
+                var interactions = item.responseProcessing.getRootElement().getInteractions();
+                if(interactions.length === 1) {
+                    const response = interactions[0].getResponseDeclaration();
+                    if(response.template === 'no_response_processing'){
+                        if(maxScoreOutcome.attributes && maxScoreOutcome.attributes.externalScored) {
+                            if(_.isUndefined(maxScoreOutcome.defaultValue)) {
+                                maxScoreOutcome.setDefaultValue(1)
+                            }
+                        } else {
+                            item.removeOutcome('MAXSCORE');
+                        }
+                    }
                 }
-            } else {
-                item.removeOutcome('MAXSCORE');
+
             }
         } 
-        
-        
+                
     },
 
     /**


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-1906

### Description

When response processing is turned off for interaction, SCORE and MAXSCORE outcome declarations are ignored and not saved into item xml, this PR allows them to be entered manually and saved

### How to test

 - run unit tests
 - check with related PR (https://github.com/oat-sa/extension-tao-itemqti/pull/2191)