### PR TITLE
Fix/tr 4451/inlinechoice empty label lost translation

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -67,7 +67,7 @@ var render = function(interaction, options) {
         const itemBody = $('.qti-itemBody');
         const itemDir = itemBody.attr('dir') || 'ltr';
         return itemDir;
-    }
+    };
 
     const dirClass = getItemDir();
     $container.select2({

--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -58,7 +58,7 @@ var render = function(interaction, options) {
     _.extend(opts, options);
 
     if (opts.allowEmpty && !required) {
-        $container.find('option[value=' + _emptyValue + ']').text(__('--- leave empty ---') || '--- ' + __('leave empty') + ' ---');
+        $container.find('option[value=' + _emptyValue + ']').text(__('--- leave empty ---'));
     } else {
         $container.find('option[value=' + _emptyValue + ']').remove();
     }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4451

Use with https://github.com/oat-sa/extension-tao-itemqti/pull/2198

Follow-up to https://github.com/oat-sa/tao-item-runner-qti-fe/pull/305

InlineChoiceInteraction empty label text:
With that solution, existing translations would be lost, because even if language doesn't have `--- leave empty ---` defined, `__('--- leave empty ---')` will not return empty string, it will just return original text in english.

So just replace old  `'--- ' + __('leave empty') + ' ---'` with new `__('--- leave empty ---')` and update all existing translations.