### PR TITLE
feat: calculate normal maximum for PCI with MAP_RESPONSE

### DIFF
--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -849,6 +849,22 @@ export default {
             } else {
                 max = 0;
             }
+        } else if (template === 'MAP_RESPONSE') {
+            //at least a map entry is required to be valid QTI
+            if (!responseDeclaration.mapEntries || !_.size(responseDeclaration.mapEntries)) {
+                return 0;
+            }
+
+            const values = _.values(responseDeclaration.mapEntries)
+                .map(function(v) {
+                    return parseFloat(v);
+                });
+            max = _.max(values);
+
+            //compare the calculated maximum with the mapping upperbound
+            if (responseDeclaration.mappingAttributes.upperBound) {
+                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
+            }
         } else {
             max = 0;
         }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4504

**Calculate maximum for PCI with MAP_RESPONSE** 

## How to test:
Create item with Math PCI, save it - normalMaximum will be 0
![image](https://user-images.githubusercontent.com/25976342/191280975-d3cea1a4-a26c-4816-ad66-d68951cbdd17.png)
Add answer, save it - normalMaximum will be 1
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/25976342/191281360-30570763-3adb-428a-8520-028ee61456d5.png">
![image](https://user-images.githubusercontent.com/25976342/191280344-1bae5835-2934-4dca-9f19-d314554eee03.png)
