### PR TITLE
fix/AUT-2713 Choice interaction - Incorrect amount of choices are allowed to be selected if maxChoices = minChoices

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -248,10 +248,25 @@ const _setInstructions = function _setInstructions(interaction) {
     } else if (min > 1 && min === max) {
         // Multiple Choice: 5. Constraint: Other constraints -> minChoices ≠ Disabled / maxChoices ≠ Disabled -> “You need to select {minChoices = maxChoices value} choices.“
         msg = __('You need to select %s choices', min);
-        instructionMgr.appendInstruction(interaction, msg, function () {
+        instructionMgr.appendInstruction(interaction, msg, function (data) {
             if (_getRawResponse(interaction).length === min) {
                 this.setLevel('success');
-            } else {
+            } else if (_getRawResponse(interaction).length >= max) {
+                this.setMessage(__('Maximum choices reached'));
+                this.update({
+                    level: 'warning',
+                    timeout: 2000,
+                    start: function () {
+                        if (data && data.choice) {
+                            highlightInvalidInput(data.choice);
+                        }
+                    },
+                    stop: function () {
+                        this.setLevel('info');
+                    }
+                });
+                this.setState('fulfilled');
+            }  else {
                 this.reset();
             }
         });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2713

**Steps to reproduce:**

- Create an Item and open it in Authoring
- D&D Choice Interaction to the canvas
- Select Multiple Choice and other Other constraints
- Set maxChoices = minChoices (e.g. 2) 
- Save and preview the Item
- Select more than maxChoices value

**Actual result:** User is able to select the value greater than maximum 
**Expected result:** “Maximum number of choices reached.“ message is displayed to the user. User is not able to select more than maximum set in constraints