### PR TITLE
fix: scale coords if background resized

### DIFF
--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -467,13 +467,14 @@ var GraphicHelper = {
      * @param {Raphael.Element} element - the shape to get the coords from
      * @returns {String} the QTI coords
      */
-    qtiCoords: function qtiCoords(element) {
+    qtiCoords: function qtiCoords(element, paper, width) {
         var mapper = raph2qtiCoordsMapper[element.type];
         var result = '';
+        var factor = paper && width ? width / paper.w : 1;
 
         if (_.isFunction(mapper)) {
             result = _.map(mapper.call(raph2qtiCoordsMapper, element.attr()), function(coord) {
-                return _.parseInt(coord);
+                return Math.round(coord * factor);
             }).join(',');
         }
 

--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -195,6 +195,7 @@ var GraphicHelper = {
         var imgWidth = options.width || $container.innerWidth();
         var imgHeight = options.height || $container.innerHeight();
 
+
         paper = scaleRaphael(id, imgWidth, imgHeight);
         image = paper.image(options.img, 0, 0, imgWidth, imgHeight);
         image.id = options.imgId || image.id;
@@ -234,10 +235,10 @@ var GraphicHelper = {
             maxWidth = $body.width();
             containerWidth = $editor.innerWidth();
 
-            if (givenWidth > 0) {
-                if (givenWidth < maxWidth) {
+            if (givenWidth > 0 || containerWidth > maxWidth) {
+                if (givenWidth > 0 && givenWidth < maxWidth) {
                     containerWidth = givenWidth;
-                } else {
+                } else if (containerWidth > maxWidth) {
                     containerWidth = maxWidth;
                 }
 
@@ -251,9 +252,8 @@ var GraphicHelper = {
                 if (typeof options.resize === 'function') {
                     options.resize(containerWidth, factor);
                 }
-
-                $container.trigger('resized.qti-widget');
             }
+            $container.trigger('resized.qti-widget');
         }
 
         return paper;

--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -225,23 +225,20 @@ var GraphicHelper = {
          * @private
          */
         function resizePaper(e, givenWidth) {
-            var diff, maxWidth, containerWidth, containerHeight, factor;
+            var maxWidth, containerWidth, containerHeight, factor;
 
             if (e) {
                 e.stopPropagation();
             }
 
-            diff = $editor.outerWidth() - $editor.width() + ($container.outerWidth() - $container.width()) + 1;
             maxWidth = $body.width();
-            containerWidth = $container.innerWidth();
+            containerWidth = $editor.innerWidth();
 
-            if (containerWidth > 0 || givenWidth > 0) {
-                if (givenWidth < containerWidth && givenWidth < maxWidth) {
-                    containerWidth = givenWidth - diff;
-                } else if (containerWidth > maxWidth) {
-                    containerWidth = maxWidth - diff;
+            if (givenWidth > 0) {
+                if (givenWidth < maxWidth) {
+                    containerWidth = givenWidth;
                 } else {
-                    containerWidth -= diff;
+                    containerWidth = maxWidth;
                 }
 
                 factor = containerWidth / imgWidth;

--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -462,6 +462,8 @@ var GraphicHelper = {
     /**
      * Get the QTI coordinates from a Raphael Element
      * @param {Raphael.Element} element - the shape to get the coords from
+     * @param {Raphael.Element} paper - the interaction paper
+     * @param {number} width - width of background image
      * @returns {String} the QTI coords
      */
     qtiCoords: function qtiCoords(element, paper, width) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1910

**!Will be separate ticket to rework responsive and fixed sizes for graphic interactions**

Issue: 
1. when size of background image for HotSpot updated - coords of shapes wasn't recalculated
2. size of image wasn't restored after reopening item in Authoring

How to test:
- go to item Authoring
- add HotSpot interaction
- add shapes on it
- go to item Style Editor, set Item width to Defined width
- set focus on HotSpot interaction
- update size
- save item
- reopen in Item Authoring, see the same size
- open in preview, see that HotSpots on proper positions and size in correct

![image](https://user-images.githubusercontent.com/25976342/196411024-fcb0a881-7e03-497a-b294-b5d45e39a2ed.png)
 
![image](https://user-images.githubusercontent.com/25976342/196411169-aefff6d0-ae16-4fe1-bff0-b77403e0bad1.png)
