### PR TITLE
fix: add parent class to Figure display inline to force flow

### DIFF
--- a/src/runner/provider/qti.js
+++ b/src/runner/provider/qti.js
@@ -97,7 +97,7 @@ var qtiItemRuntimeProvider = {
                 const figures = $itemBody.find(`.${alignmentHelper.INLINE_CLASS}`);
                 figures.each((i, fig) => {
                     $(fig).parent().parent().addClass(`parent-${alignmentHelper.INLINE_CLASS}`);
-                })
+                });
             } catch (e) {
                 self.trigger('error', __('Error in template rendering: %s', e.message));
             }

--- a/src/runner/provider/qti.js
+++ b/src/runner/provider/qti.js
@@ -36,6 +36,7 @@ import userModules from 'taoQtiItem/runner/provider/manager/userModules';
 import modalFeedbackHelper from 'taoQtiItem/qtiItem/helper/modalFeedback';
 import 'taoItems/assets/manager';
 import locale from 'util/locale';
+import alignmentHelper from 'ui/mediaEditor/plugins/mediaAlignment/helper';
 
 var timeout = (context.timeout > 0 ? context.timeout + 1 : 30) * 1000;
 
@@ -91,6 +92,12 @@ var qtiItemRuntimeProvider = {
                     const itemLang = $item.attr('lang');
                     $itemBody.attr('dir', locale.getLanguageDirection(itemLang));
                 }
+
+                // Add parent class to force inline flow on Figure tag
+                const figures = $itemBody.find(`.${alignmentHelper.INLINE_CLASS}`);
+                figures.each((i, fig) => {
+                    $(fig).parent().parent().addClass(`parent-${alignmentHelper.INLINE_CLASS}`);
+                })
             } catch (e) {
                 self.trigger('error', __('Error in template rendering: %s', e.message));
             }


### PR DESCRIPTION
**Related to:** [AUT-2673](https://oat-sa.atlassian.net/browse/AUT-2673)

**Description:**
Display Image inline on Figure tag

**Changes:**
The Figure tag is a block tag, so the better approach is to fake the flow with CSS.
- Add a `display: flex` property to the Feature and siblings elements wrapper, forcing the inline flow.

**Companion PRs**
- https://github.com/oat-sa/tao-core/pull/3654
- https://github.com/oat-sa/extension-tao-itemqti/pull/2256

**How to check:**

**On Assets** 
- Create an Asset with a text block. Add in the middle of the text an image. Play with the inline panel controls of the image to check if it is positioned correctly.
- Check Preview.

**On Items**
- Repeat the previous step on Assets.
- Add the previously created Asset with the Figure image on the inline position to check the position of the Asset image inside the Item.
- Check Preview

**On Tests**
- Check Terre Preview

**Delivery Terre**
- Check a test on Delivery
