### PR TITLE
Fix/aut 2716/association interaction not able to add pairs after mediaplayer

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -34,21 +34,21 @@ import sizeAdapter from 'taoQtiItem/qtiCommonRenderer/helpers/sizeAdapter';
 import interact from 'interact';
 import interactUtils from 'ui/interactUtils';
 
-var setChoice = function(interaction, $choice, $target) {
-    var $container = containerHelper.get(interaction);
-    var choiceSerial = $choice.data('serial');
-    var usage = $choice.data('usage') || 0;
-    var choice = interaction.getChoice(choiceSerial);
+const setChoice = function(interaction, $choice, $target) {
+    const $container = containerHelper.get(interaction);
+    const choiceSerial = $choice.data('serial');
+    const choice = interaction.getChoice(choiceSerial);
+    let usage = $choice.data('usage') || 0;
 
     if (!choiceSerial) {
-        throw 'empty choice serial';
+        throw new Error('empty choice serial');
     }
 
     //to track number of times a choice is used in a pair
     usage++;
     $choice.data('usage', usage);
 
-    var _setChoice = function() {
+    const _setChoice = function() {
         $target
             .data('serial', choiceSerial)
             .html($choice.html())
@@ -60,19 +60,19 @@ var setChoice = function(interaction, $choice, $target) {
     };
 
     if ($target.siblings('div').hasClass('filled')) {
-        var $resultArea = $('.result-area', $container),
-            $pair = $target.parent(),
-            thisPairSerial = [$target.siblings('div').data('serial'), choiceSerial],
-            $otherRepeatedPair = $();
+        const $resultArea = $('.result-area', $container);
+        const $pair = $target.parent();
+        const thisPairSerial = [$target.siblings('div').data('serial'), choiceSerial];
+        let $otherRepeatedPair = $();
 
         //check if it is not a repeating association!
         $resultArea
             .children()
             .not($pair)
             .each(function() {
-                var $otherPair = $(this).children('.filled');
+                let $otherPair = $(this).children('.filled');
                 if ($otherPair.length === 2) {
-                    var otherPairSerial = [$($otherPair[0]).data('serial'), $($otherPair[1]).data('serial')];
+                    let otherPairSerial = [$($otherPair[0]).data('serial'), $($otherPair[1]).data('serial')];
                     if (_.intersection(thisPairSerial, otherPairSerial).length === 2) {
                         $otherRepeatedPair = $otherPair;
                         return false;
@@ -123,16 +123,16 @@ var setChoice = function(interaction, $choice, $target) {
     }
 };
 
-var unsetChoice = function(interaction, $filledChoice, animate, triggerChange) {
-    var $container = containerHelper.get(interaction);
-    var choiceSerial = $filledChoice.data('serial');
-    var $choice = $container.find('.choice-area [data-serial=' + choiceSerial + ']');
-    var usage = $choice.data('usage') || 0;
-    var $parent = $filledChoice.parent();
-    var $sibling = $container.find(
+const unsetChoice = function(interaction, $filledChoice, animate, triggerChange) {
+    const $container = containerHelper.get(interaction);
+    const choiceSerial = $filledChoice.data('serial');
+    const $choice = $container.find('.choice-area [data-serial=' + choiceSerial + ']');
+    const $parent = $filledChoice.parent();
+    const $sibling = $container.find(
         '.choice-area [data-serial=' + $filledChoice.siblings('.target').data('serial') + ']'
     );
-    var isNumberOfMaxAssociationsZero = parseInt(interaction.attr('maxAssociations')) === 0;
+    const isNumberOfMaxAssociationsZero = parseInt(interaction.attr('maxAssociations')) === 0;
+    let usage = $choice.data('usage') || 0;
 
     //decrease the  use for this choice
     usage--;
@@ -176,27 +176,27 @@ var unsetChoice = function(interaction, $filledChoice, animate, triggerChange) {
     }
 };
 
-var getChoice = function(interaction, identifier) {
-    var $container = containerHelper.get(interaction);
+const getChoice = function(interaction, identifier) {
+    const $container = containerHelper.get(interaction);
 
     //warning: do not use selector data-identifier=identifier because data-identifier may change dynamically
-    var choice = interaction.getChoiceByIdentifier(identifier);
+    const choice = interaction.getChoiceByIdentifier(identifier);
     if (!choice) {
         throw new Error('cannot find a choice with the identifier : ' + identifier);
     }
     return $('.choice-area [data-serial=' + choice.getSerial() + ']', $container);
 };
 
-var renderEmptyPairs = function(interaction) {
-    var $container = containerHelper.get(interaction);
-    var max = parseInt(interaction.attr('maxAssociations'));
-    var $resultArea = $('.result-area', $container);
+const renderEmptyPairs = function(interaction) {
+    const $container = containerHelper.get(interaction);
+    const max = parseInt(interaction.attr('maxAssociations'));
+    const $resultArea = $('.result-area', $container);
 
     if (interaction.responseMappingMode || max === 0) {
         $resultArea.append(pairTpl({ empty: true }));
         hider.show($resultArea.children('.incomplete-pair'));
     } else {
-        for (var i = 0; i < max; i++) {
+        for (let i = 0; i < max; i++) {
             $resultArea.append(pairTpl());
         }
     }
@@ -207,12 +207,12 @@ var renderEmptyPairs = function(interaction) {
  * @param {jQuery} $scrollContainer
  * @returns {scrollObserver}
  */
-var scrollObserverFactory = function scrollObserverFactory($scrollContainer) {
-    var currentDraggable = null;
-    var beforeY = 0;
-    var beforeX = 0;
-    var afterY = 0;
-    var afterX = 0;
+const scrollObserverFactory = function scrollObserverFactory($scrollContainer) {
+    let currentDraggable = null;
+    let beforeY = 0;
+    let beforeX = 0;
+    let afterY = 0;
+    let afterX = 0;
 
     // reset the scroll observer context
     function resetScrollObserver() {
@@ -225,7 +225,8 @@ var scrollObserverFactory = function scrollObserverFactory($scrollContainer) {
 
     // keep the position of the dragged element accurate with the scroll position
     function onScrollCb() {
-        var x, y;
+        let x;
+        let y;
         if (currentDraggable) {
             beforeY = afterY;
             beforeX = afterX;
@@ -252,8 +253,8 @@ var scrollObserverFactory = function scrollObserverFactory($scrollContainer) {
 
     // find the scroll container within the parents if any
     $scrollContainer.parents().each(function findScrollContainer() {
-        var $el = $(this);
-        var ovf = $el.css('overflow');
+        const $el = $(this);
+        const ovf = $el.css('overflow');
         if (ovf !== 'hidden' && ovf !== 'visible') {
             $scrollContainer = $el;
             return false;
@@ -294,7 +295,50 @@ var scrollObserverFactory = function scrollObserverFactory($scrollContainer) {
         }
     };
 };
+const _getRawResponse = function(interaction) {
+    const response = [];
+    const $container = containerHelper.get(interaction);
+    $('.result-area>li', $container).each(function() {
+        const pair = [];
+        $(this)
+            .find('div')
+            .each(function() {
+                const serial = $(this).data('serial');
+                if (serial && !/^qtiobject_/.test(serial) && !/^object_/.test(serial)) {
+                    pair.push(interaction.getChoice(serial).id());
+                }
+            });
+        if (pair.length === 2) {
+            response.push(pair);
+        }
+    });
+    return response;
+};
+const _setInstructions = function(interaction) {
+    const min = parseInt(interaction.attr('minAssociations'), 10);
+    const max = parseInt(interaction.attr('maxAssociations'), 10);
 
+    //infinite association:
+    if (min === 0) {
+        if (max === 0) {
+            instructionMgr.appendInstruction(interaction, __('You may make as many association pairs as you want.'));
+        }
+    } else {
+        if (max === 0) {
+            instructionMgr.appendInstruction(interaction, __('The maximum number of association is unlimited.'));
+        }
+        //the max value is implicit since the appropriate number of empty pairs have already been created
+        let msg = __('You need to make') + ' ';
+        msg += min > 1 ? __('at least') + ' ' + min + ' ' + __('association pairs') : __('one association pair');
+        instructionMgr.appendInstruction(interaction, msg, function() {
+            if (_getRawResponse(interaction).length >= min) {
+                this.setLevel('success');
+            } else {
+                this.reset();
+            }
+        });
+    }
+};
 /**
  * Init rendering, called after template injected into the DOM
  * All options are listed in the QTI v2.1 information model:
@@ -302,29 +346,29 @@ var scrollObserverFactory = function scrollObserverFactory($scrollContainer) {
  *
  * @param {object} interaction
  */
-var render = function(interaction) {
-    var self = this;
+const render = function(interaction) {
+    const self = this;
 
-    return new Promise(function(resolve, reject) {
-        var $container = containerHelper.get(interaction);
-        var $choiceArea = $container.find('.choice-area');
-        var $resultArea = $container.find('.result-area');
+    return new Promise(function(resolve) {
+        const $container = containerHelper.get(interaction);
+        const $choiceArea = $container.find('.choice-area');
+        const $resultArea = $container.find('.result-area');
 
-        var $activeChoice = null;
-        var scrollObserver = null;
+        let $activeChoice = null;
+        let scrollObserver = null;
 
-        var isDragAndDropEnabled;
-        var dragOptions;
-        var dropOptions;
-        var scaleX, scaleY;
+        let isDragAndDropEnabled;
+        let dragOptions;
+        let dropOptions;
+        let scaleX, scaleY;
 
-        var $bin = $('<span>', { class: 'icon-undo remove-choice', title: __('remove') });
+        let $bin = $('<span>', { class: 'icon-undo remove-choice', title: __('remove') });
 
-        var choiceSelector = $choiceArea.selector + ' >li';
-        var resultSelector = $resultArea.selector + ' >li>div';
-        var binSelector = $container.selector + ' .remove-choice';
+        let choiceSelector = $choiceArea.selector + ' >li';
+        let resultSelector = $resultArea.selector + ' >li>div';
+        let binSelector = $container.selector + ' .remove-choice';
 
-        var _getChoice = function(serial) {
+        let _getChoice = function(serial) {
             return $choiceArea.find('[data-serial=' + serial + ']');
         };
 
@@ -334,14 +378,14 @@ var render = function(interaction) {
          * @param $target
          * @private
          */
-        var _setChoice = function($choice, $target) {
+        const _setChoice = function($choice, $target) {
             setChoice(interaction, $choice, $target);
             sizeAdapter.adaptSize(
                 $('.result-area .target, .choice-area .qti-choice', containerHelper.get(interaction))
             );
         };
 
-        var _resetSelection = function() {
+        const _resetSelection = function() {
             if ($activeChoice) {
                 $resultArea.find('.remove-choice').remove();
                 $activeChoice.removeClass('active');
@@ -350,22 +394,28 @@ var render = function(interaction) {
             }
         };
 
-        var _unsetChoice = function($choice) {
+        const _unsetChoice = function($choice) {
             unsetChoice(interaction, $choice, true);
             sizeAdapter.adaptSize(
                 $('.result-area .target, .choice-area .qti-choice', containerHelper.get(interaction))
             );
         };
 
-        var _isInsertionMode = function() {
+        const _isInsertionMode = function() {
             return $activeChoice && $activeChoice.data('identifier');
         };
 
-        var _isModeEditing = function() {
+        const _isModeEditing = function() {
             return $activeChoice && !$activeChoice.data('identifier');
         };
+        const _activateChoice = function($choice) {
+            _resetSelection();
+            $activeChoice = $choice;
+            $choice.addClass('active');
+            $resultArea.find('>li>.target').addClass('empty');
+        };
 
-        var _handleChoiceActivate = function($target) {
+        const _handleChoiceActivate = function($target) {
             if ($target.hasClass('deactivated')) {
                 return;
             }
@@ -385,16 +435,29 @@ var render = function(interaction) {
                 }
             }
         };
+        const _activateResult = function($target) {
+            const targetSerial = $target.data('serial');
 
-        var _activateChoice = function($choice) {
-            _resetSelection();
-            $activeChoice = $choice;
-            $choice.addClass('active');
-            $resultArea.find('>li>.target').addClass('empty');
+            $activeChoice = $target;
+            $activeChoice.addClass('active');
+
+            $resultArea
+                .find('>li>.target')
+                .filter(function() {
+                    return $(this).data('serial') !== targetSerial;
+                })
+                .addClass('empty');
+
+            $choiceArea
+                .find('>li:not(.deactivated)')
+                .filter(function() {
+                    return $(this).data('serial') !== targetSerial;
+                })
+                .addClass('empty');
         };
 
-        var _handleResultActivate = function($target) {
-            var choiceSerial,
+        const _handleResultActivate = function($target) {
+            let choiceSerial,
                 targetSerial = $target.data('serial');
 
             if (_isInsertionMode()) {
@@ -442,27 +505,6 @@ var render = function(interaction) {
             }
         };
 
-        var _activateResult = function($target) {
-            var targetSerial = $target.data('serial');
-
-            $activeChoice = $target;
-            $activeChoice.addClass('active');
-
-            $resultArea
-                .find('>li>.target')
-                .filter(function() {
-                    return $(this).data('serial') !== targetSerial;
-                })
-                .addClass('empty');
-
-            $choiceArea
-                .find('>li:not(.deactivated)')
-                .filter(function() {
-                    return $(this).data('serial') !== targetSerial;
-                })
-                .addClass('empty');
-        };
-
         // Point & click handlers
 
         interact($container.selector).on('tap', function(e) {
@@ -479,7 +521,7 @@ var render = function(interaction) {
         });
 
         interact($choiceArea.selector + ' >li').on('tap', function(e) {
-            var $target = $(e.currentTarget);
+            const $target = $(e.currentTarget);
 
             //if tts component is loaded and click-to-speak function is activated - we should prevent this listener to go further
             if ($target.closest('.qti-item').hasClass('prevent-click-handler')) {
@@ -492,7 +534,7 @@ var render = function(interaction) {
         });
 
         interact($resultArea.selector + ' >li>div').on('tap', function(e) {
-            var $target = $(e.currentTarget);
+            const $target = $(e.currentTarget);
 
             //if tts component is loaded and click-to-speak function is activated - we should prevent this listener to go further
             if ($target.closest('.qti-item').hasClass('prevent-click-handler')) {
@@ -532,7 +574,7 @@ var render = function(interaction) {
 
         function _iFrameDragFix(draggableSelector, target) {
             interactUtils.iFrameDragFixOn(function() {
-                var $activeDrop = $(resultSelector + '.dropzone');
+                let $activeDrop = $(resultSelector + '.dropzone');
                 if ($activeDrop.length) {
                     interact(resultSelector).fire({
                         type: 'drop',
@@ -575,8 +617,8 @@ var render = function(interaction) {
                     _.defaults(
                         {
                             onstart: function(e) {
-                                var $target = $(e.target);
-                                var scale;
+                                let $target = $(e.target);
+                                let scale;
                                 $target.addClass('dragged');
                                 _activateChoice($target);
                                 _iFrameDragFix(choiceSelector + ':not(.deactivated)', e.target);
@@ -590,7 +632,7 @@ var render = function(interaction) {
                                 interactUtils.moveElement(e.target, e.dx / scaleX, e.dy / scaleY);
                             },
                             onend: function(e) {
-                                var $target = $(e.target);
+                                let $target = $(e.target);
                                 $target.removeClass('dragged');
                                 // The reason of placing delay here is that there was timing conflict between "draggable" and "drag-zone" elements.
                                 _.delay(function(){
@@ -613,8 +655,8 @@ var render = function(interaction) {
                     _.defaults(
                         {
                             onstart: function(e) {
-                                var $target = $(e.target);
-                                var scale;
+                                let $target = $(e.target);
+                                let scale;
                                 $target.addClass('dragged');
                                 _resetSelection();
                                 _activateResult($target);
@@ -629,7 +671,7 @@ var render = function(interaction) {
                                 interactUtils.moveElement(e.target, e.dx / scaleX, e.dy / scaleY);
                             },
                             onend: function(e) {
-                                var $target = $(e.target);
+                                let $target = $(e.target);
                                 $target.removeClass('dragged');
 
                                 interactUtils.restoreOriginalPosition($target);
@@ -698,34 +740,8 @@ var render = function(interaction) {
     });
 };
 
-var _setInstructions = function(interaction) {
-    var min = parseInt(interaction.attr('minAssociations'), 10),
-        max = parseInt(interaction.attr('maxAssociations'), 10);
-
-    //infinite association:
-    if (min === 0) {
-        if (max === 0) {
-            instructionMgr.appendInstruction(interaction, __('You may make as many association pairs as you want.'));
-        }
-    } else {
-        if (max === 0) {
-            instructionMgr.appendInstruction(interaction, __('The maximum number of association is unlimited.'));
-        }
-        //the max value is implicit since the appropriate number of empty pairs have already been created
-        var msg = __('You need to make') + ' ';
-        msg += min > 1 ? __('at least') + ' ' + min + ' ' + __('association pairs') : __('one association pair');
-        instructionMgr.appendInstruction(interaction, msg, function() {
-            if (_getRawResponse(interaction).length >= min) {
-                this.setLevel('success');
-            } else {
-                this.reset();
-            }
-        });
-    }
-};
-
-var resetResponse = function(interaction) {
-    var $container = containerHelper.get(interaction);
+const resetResponse = function(interaction) {
+    const $container = containerHelper.get(interaction);
 
     //destroy selected choice:
     $container.find('.result-area .active').each(function() {
@@ -740,16 +756,16 @@ var resetResponse = function(interaction) {
     instructionMgr.validateInstructions(interaction);
 };
 
-var _setPairs = function(interaction, pairs) {
-    var $container = containerHelper.get(interaction);
-    var addedPairs = 0;
-    var $emptyPair = $('.result-area>li:first', $container);
+const _setPairs = function(interaction, pairs) {
+    const $container = containerHelper.get(interaction);
+    let addedPairs = 0;
+    let $emptyPair = $('.result-area>li:first', $container);
     if (pairs && interaction.getResponseDeclaration().attr('cardinality') === 'single' && pairs.length) {
         pairs = [pairs];
     }
     _.each(pairs, function(pair) {
         if ($emptyPair.length) {
-            var $divs = $emptyPair.children('div');
+            let $divs = $emptyPair.children('div');
             setChoice(interaction, getChoice(interaction, pair[0]), $($divs[0]));
             setChoice(interaction, getChoice(interaction, pair[1]), $($divs[1]));
             addedPairs++;
@@ -775,28 +791,8 @@ var _setPairs = function(interaction, pairs) {
  * @param {object} interaction
  * @param {object} response
  */
-var setResponse = function(interaction, response) {
+const setResponse = function(interaction, response) {
     _setPairs(interaction, pciResponse.unserialize(response, interaction));
-};
-
-var _getRawResponse = function(interaction) {
-    var response = [];
-    var $container = containerHelper.get(interaction);
-    $('.result-area>li', $container).each(function() {
-        var pair = [];
-        $(this)
-            .find('div')
-            .each(function() {
-                var serial = $(this).data('serial');
-                if (serial && !/^qtiobject_/.test(serial) && !/^object_/.test(serial)) {
-                    pair.push(interaction.getChoice(serial).id());
-                }
-            });
-        if (pair.length === 2) {
-            response.push(pair);
-        }
-    });
-    return response;
 };
 
 /**
@@ -811,7 +807,7 @@ var _getRawResponse = function(interaction) {
  * @param {object} interaction
  * @returns {object}
  */
-var getResponse = function(interaction) {
+const getResponse = function(interaction) {
     return pciResponse.serialize(_getRawResponse(interaction), interaction);
 };
 
@@ -819,8 +815,8 @@ var getResponse = function(interaction) {
  * Destroy the interaction by leaving the DOM exactly in the same state it was before loading the interaction.
  * @param {Object} interaction - the interaction
  */
-var destroy = function(interaction) {
-    var $container = containerHelper.get(interaction);
+const destroy = function(interaction) {
+    const $container = containerHelper.get(interaction);
 
     //remove event
     interact($container.selector).unset();
@@ -843,8 +839,8 @@ var destroy = function(interaction) {
  * @param {Object} interaction - the interaction instance
  * @param {Object} state - the interaction state
  */
-var setState = function setState(interaction, state) {
-    var $container;
+const setState = function setState(interaction, state) {
+    let $container;
 
     if (_.isObject(state)) {
         if (state.response) {
@@ -858,8 +854,8 @@ var setState = function setState(interaction, state) {
 
             $('.choice-area .qti-choice', $container)
                 .sort(function(a, b) {
-                    var aIndex = _.indexOf(state.order, $(a).data('identifier'));
-                    var bIndex = _.indexOf(state.order, $(b).data('identifier'));
+                    let aIndex = _.indexOf(state.order, $(a).data('identifier'));
+                    let bIndex = _.indexOf(state.order, $(b).data('identifier'));
                     if (aIndex > bIndex) {
                         return 1;
                     }
@@ -880,10 +876,10 @@ var setState = function setState(interaction, state) {
  * @param {Object} interaction - the interaction instance
  * @returns {Object} the interaction current state
  */
-var getState = function getState(interaction) {
-    var $container;
-    var state = {};
-    var response = interaction.getResponse();
+const getState = function getState(interaction) {
+    let $container;
+    let state = {};
+    let response = interaction.getResponse();
 
     if (response) {
         state.response = response;

--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -788,7 +788,7 @@ var _getRawResponse = function(interaction) {
             .find('div')
             .each(function() {
                 var serial = $(this).data('serial');
-                if (serial) {
+                if (serial && !/^qtiobject_/.test(serial) && !/^object_/.test(serial)) {
                     pair.push(interaction.getChoice(serial).id());
                 }
             });


### PR DESCRIPTION
**Related to:**
https://oat-sa.atlassian.net/browse/AUT-2716
**STEPS TO TEST:**

1. Create an item with a common associate interaction
2. Add photo, audio and video elements.
3. Go to preview and create pairs

**CURRENT RESULT:**

- When adding a video or audio file in second element pair, error shows in console and new pair gaps don't show.

**EXPECTED RESULT:**

- When adding a pair no matter what content is present in choice, no errors show in console and new pair gap is present 
- Response scores in delivery and preview work as expected.

![associatePairs](https://user-images.githubusercontent.com/60346520/201348457-2b4dce11-5601-47ba-8802-c5c99aaa7f24.gif)


