### PR TITLE
fix: support old inline figure

### DIFF
--- a/src/qtiCommonRenderer/renderers/Figure.js
+++ b/src/qtiCommonRenderer/renderers/Figure.js
@@ -43,7 +43,7 @@ export default {
     render: function(figure) {
         const $figure = containerHelper.get(figure);
         const $img = $figure.find('img');
-        if ($img.length) {
+        if ($img.length && $figure.prop('tagName') === 'FIGURE') {
             // move width from image to figure
             $figure.css({ width: $img.attr('width') });
             $img.attr('width', '100%');

--- a/src/qtiCommonRenderer/tpl/figure.tpl
+++ b/src/qtiCommonRenderer/tpl/figure.tpl
@@ -5,7 +5,7 @@
     {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
 >{{{body}}}</figure>
 {{else}}
-<span data-serial="{{serial}}">
+<span data-serial="{{serial}}" data-figure="true">
     {{{body}}}
 </span>
 {{/if}}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2673

Issue with edit old inline figure. On customer env serial doesn't contain `figure_` in serial, then was added `data-figure="true"` flag. Also no need to move width in case parent is not `figure` (`span` in case it is inline).


