### PR TITLE
Hotfix/aut 2673/support old inline figure to November release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-item-runner-qti",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "displayName": "TAO Item Runner QTI",
     "description": "TAO QTI Item Runner modules",
     "files": [

--- a/src/qtiCommonRenderer/renderers/Figure.js
+++ b/src/qtiCommonRenderer/renderers/Figure.js
@@ -43,7 +43,7 @@ export default {
     render: function(figure) {
         const $figure = containerHelper.get(figure);
         const $img = $figure.find('img');
-        if ($img.length) {
+        if ($img.length && $figure.prop('tagName') === 'FIGURE') {
             // move width from image to figure
             $figure.css({ width: $img.attr('width') });
             $img.attr('width', '100%');

--- a/src/qtiCommonRenderer/tpl/figure.tpl
+++ b/src/qtiCommonRenderer/tpl/figure.tpl
@@ -5,7 +5,7 @@
     {{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}
 >{{{body}}}</figure>
 {{else}}
-<span data-serial="{{serial}}">
+<span data-serial="{{serial}}" data-figure="true">
     {{{body}}}
 </span>
 {{/if}}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2673

Backport of https://github.com/oat-sa/tao-item-runner-qti-fe/pull/341 to [November release](https://github.com/oat-sa/tao-community/blob/2022.11.4/composer.json#L39) [taoQtiITem v29.14.4.4](https://github.com/oat-sa/extension-tao-itemqti/blob/v29.14.4.4/views/package.json#L12)