### PR TITLE
fix: forward responseDeclaration to ims pci

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
+++ b/src/qtiCommonRenderer/renderers/interactions/pci/ims.js
@@ -96,6 +96,17 @@ export default function defaultPciRenderer(runtime) {
                 status: 'interacting' //only support interacting state currently(TODO: solution, review),
             };
 
+            const responseIdentifier  = interaction.attributes.responseIdentifier;
+            let responseDeclaration;
+            if(responseIdentifier && interaction.rootElement && interaction.rootElement.responses) {
+                Object.keys(interaction.rootElement.responses).forEach(responseKey => {
+                    if(interaction.rootElement.responses[responseKey].attributes.identifier === responseIdentifier) {
+                        responseDeclaration = interaction.rootElement.responses[responseKey].attributes;
+                        config.properties.responseDeclaration = responseDeclaration;
+                    }
+                })
+            }
+
             pciConstructor.getInstance(containerHelper.get(interaction).get(0), config, context.state);
 
             return readyPromise.then(instance => {


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/LSI-1548

### Description

Legacy MathEntry PCI have cardinality: multiple in gap mode. New mathEntry pci runtime shapes single cardinality response, this leads to error 500 on backend when such response cannot be handled by backend

This PR makes ims.js to forward response declaration to PCI runtime

### How to test

Needs to be tested with changes to mathEntryPCI 