### PR TITLE
fix: compatibility with `text`-based inline choice options

### DIFF
--- a/src/qtiItem/core/Loader.js
+++ b/src/qtiItem/core/Loader.js
@@ -402,7 +402,7 @@ var Loader = Class.extend({
 
         let body = data.body;
         if (!body && data.text && data.qtiClass === 'inlineChoice') {
-            body = {body: data.text, elements: []};
+            body = { body: data.text, elements: {} };
         }
         if (element.body && body) {
             if (element.bdy) {

--- a/src/qtiItem/core/Loader.js
+++ b/src/qtiItem/core/Loader.js
@@ -400,9 +400,13 @@ var Loader = Class.extend({
         const attributes = _.defaults(data.attributes || {}, element.attributes || {});
         element.setAttributes(attributes);
 
-        if (element.body && data.body) {
+        let body = data.body;
+        if (!body && data.text && data.qtiClass === 'inlineChoice') {
+            body = {body: data.text, elements: []};
+        }
+        if (element.body && body) {
             if (element.bdy) {
-                this.loadContainer(element.getBody(), data.body);
+                this.loadContainer(element.getBody(), body);
             }
         }
 


### PR DESCRIPTION
# [OATSD-2361](https://oat-sa.atlassian.net/browse/OATSD-2361)

This PR aims to fix `inlineChoice`'s compatibility with its older data format relying on `text` attribute while keeping the new implementation relying on the `body` element.


https://user-images.githubusercontent.com/2943256/221191076-4bea3b63-1c02-4e7f-ad43-620dc5e4a284.mov



[OATSD-2361]: https://oat-sa.atlassian.net/browse/OATSD-2361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ