### PR TITLE
fix: updates overlap options

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -692,7 +692,7 @@ const render = function(interaction) {
                 .styleCursor(false);
 
             dropOptions = {
-                overlap: 0.15,
+                overlap: 'pointer',
                 ondragenter: function(e) {
                     $(e.target).addClass('dropzone');
                     $(e.relatedTarget).addClass('droppable');


### PR DESCRIPTION
coming from [https://oat-sa.atlassian.net/browse/AUT-3027](https://oat-sa.atlassian.net/browse/AUT-3027)

changelog:

* change drop options to enable drop area when mouse is on over while dragging