### PR TITLE
feature: check for interaction choice validity before add its id

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -306,7 +306,7 @@ const _getRawResponse = function(interaction) {
                 const serial = $(this).data('serial');
                 if (serial) {
                     const choice = interaction.getChoice(serial);
-                    if (!!choice) {
+                    if (choice) {
                         pair.push(choice.id());
                     }
                 }

--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -304,8 +304,11 @@ const _getRawResponse = function(interaction) {
             .find('div')
             .each(function() {
                 const serial = $(this).data('serial');
-                if (serial && !/^qtiobject_/.test(serial) && !/^object_/.test(serial)) {
-                    pair.push(interaction.getChoice(serial).id());
+                if (serial) {
+                    const choice = interaction.getChoice(serial);
+                    if (!!choice) {
+                        pair.push(choice.id());
+                    }
                 }
             });
         if (pair.length === 2) {


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-2716

- What's Changed

Check for choice object before get its ID to avoid null access.

- How to test (took from ticket)

1. Go to Items tab
2. Choose an item from Preconditions and click ‘Preview’
3. Drag and drop 1 choice containing the media and one without it into the empty association pair
Actual result: Pair is created but user cannot create more pairs, empty pair doesn’t appear. Several errors appear in browser console, the last dragged choice is stuck with mouse cursor.
Expected result: Association pair is added, empty pair appears so it is possible to create a new association pair. No errors in DevTools console.