### PR TITLE
Fix TR-5398 unwanted style removal on choice interaction validation

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -186,8 +186,13 @@ const _setInstructions = function _setInstructions(interaction) {
 
     const highlightInvalidInput = function highlightInvalidInput($choice) {
         const $input = $choice.find('.real-label > input');
-        const $li = $choice.css('color', '#BA122B');
-        const $icon = $choice.find('.real-label > span').css('color', '#BA122B').addClass('cross error');
+        const $icon = $choice.find('.real-label > span');
+
+        const choiceStyle = $choice.attr('style');
+        const iconStyle = $icon.attr('style');
+        $choice.css('color', '#BA122B');
+        $icon.css('color', '#BA122B').addClass('cross error')
+
         let timeout = interaction.data('__instructionTimeout');
 
         if (timeout) {
@@ -195,9 +200,9 @@ const _setInstructions = function _setInstructions(interaction) {
         }
         timeout = setTimeout(function () {
             $input.prop('checked', false);
-            $li.removeAttr('style');
-            $icon.removeAttr('style').removeClass('cross');
-            $li.toggleClass('user-selected', false);
+            $choice.attr('style', choiceStyle);
+            $icon.attr('style', iconStyle).removeClass('cross');
+            $choice.toggleClass('user-selected', false);
             containerHelper.triggerResponseChangeEvent(interaction);
         }, 150);
         interaction.data('__instructionTimeout', timeout);

--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -355,7 +355,7 @@ const resetResponse = function resetResponse(interaction) {
  * http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10278
  *
  * @param {Object} interaction - the interaction instance
- * @param {0bject} response - the PCI formated response
+ * @param {Object} response - the PCI formatted response
  */
 const setResponse = function setResponse(interaction, response) {
     const $container = containerHelper.get(interaction);


### PR DESCRIPTION
# [TR-5398](https://oat-sa.atlassian.net/browse/TR-5398)

This PR addresses an issue of losing the item-level styles of certain parts of a choice interaction upon resetting the invalid-response state.
⚠️ The fix is far from being perfect as obviously a better option would be to introduce proper validation-error-state CSS classes, but will do for the time being.

|Before|After|
|-|-|
|<img width="928" alt="image" src="https://user-images.githubusercontent.com/2943256/233975052-5ebf44a3-924b-4cd7-8b32-080fee7816c5.png">|<img width="928" alt="image" src="https://user-images.githubusercontent.com/2943256/233974970-dff7f4ab-8e83-4bdb-8f40-21fb7107f140.png">|

## How to test

1. Have an item with a horizontal layout choice interaction
2. Have some images with static size as choice options
3. Have a max-choice validation applied
4. Select more than allowed choices

The attached item can be used to verify the fix.
[choice_1682330836.zip](https://github.com/oat-sa/tao-item-runner-qti-fe/files/11309593/choice_1682330836.zip)

[TR-5398]: https://oat-sa.atlassian.net/browse/TR-5398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ