### PR TITLE
fix/AUT-3093-math-expression-overflow

### DIFF
--- a/src/qtiCommonRenderer/renderers/Math.js
+++ b/src/qtiCommonRenderer/renderers/Math.js
@@ -38,6 +38,12 @@ export default {
     template: tpl,
     getContainer: containerHelper.get,
     render: function render(math) {
+        $("body").on("mathjaxRendered", function(event, reference) {
+            if($(reference).find('math').length !== 0) {
+                $(reference).closest('.qti-choice').addClass('flexible-choice-width');
+            }
+        });
+        
         return new Promise(function (resolve) {
             const $self = containerHelper.get(math);
             if (typeof MathJax !== 'undefined' && MathJax) {
@@ -48,7 +54,10 @@ export default {
                 //defer execution fix some rendering issue in chrome
                 if ($self.length) {
                     MathJax.Hub.Queue(['Typeset', MathJax.Hub, $self[0]]);
-                    MathJax.Hub.Queue(resolve);
+                    MathJax.Hub.Queue(function () {
+                        $("body").trigger("mathjaxRendered", [$self[0]]);
+                        resolve();
+                    });
                 } else {
                     resolve();
                 }

--- a/src/qtiCommonRenderer/renderers/Math.js
+++ b/src/qtiCommonRenderer/renderers/Math.js
@@ -26,6 +26,7 @@
 import tpl from 'taoQtiItem/qtiCommonRenderer/tpl/math';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
 import MathJax from 'mathJax';
+import $ from 'jquery';
 
 // Do not wait between rendering each individual math element
 // http://docs.mathjax.org/en/latest/api/hub.html

--- a/src/qtiCommonRenderer/renderers/Math.js
+++ b/src/qtiCommonRenderer/renderers/Math.js
@@ -38,12 +38,12 @@ export default {
     template: tpl,
     getContainer: containerHelper.get,
     render: function render(math) {
-        $("body").on("mathjaxRendered", function(event, reference) {
-            if($(reference).find('math').length !== 0) {
+        $('body').on('mathjaxRendered', function (event, reference) {
+            if ($(reference).find('math').length !== 0) {
                 $(reference).closest('.qti-choice').addClass('flexible-choice-width');
             }
         });
-        
+
         return new Promise(function (resolve) {
             const $self = containerHelper.get(math);
             if (typeof MathJax !== 'undefined' && MathJax) {
@@ -55,7 +55,7 @@ export default {
                 if ($self.length) {
                     MathJax.Hub.Queue(['Typeset', MathJax.Hub, $self[0]]);
                     MathJax.Hub.Queue(function () {
-                        $("body").trigger("mathjaxRendered", [$self[0]]);
+                        $('body').trigger('mathjaxRendered', [$self[0]]);
                         resolve();
                     });
                 } else {

--- a/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/AssociateInteraction.js
@@ -738,7 +738,6 @@ const render = function(interaction) {
         renderEmptyPairs(interaction);
 
         sizeAdapter.adaptSize($('.result-area .target, .choice-area .qti-choice', $container));
-
         resolve();
     });
 };


### PR DESCRIPTION
coming from [AUT-3093](https://oat-sa.atlassian.net/browse/AUT-3093)
changelog:
* adds logic to math renderer to make sure math choiceblocks have no max width

how to test:
http://test-rgomez1.playground.kitchen.it.taocloud.org:42051/

[AUT-3093]: https://oat-sa.atlassian.net/browse/AUT-3093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ