### PR TITLE
feat: update MAXSCORE with external SCORE value

### DIFF
--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -37,6 +37,7 @@ var pairExists = function pairExists(collection, pair) {
     }
     return collection[pair[0] + ' ' + pair[1]] || collection[pair[1] + ' ' + pair[0]];
 };
+const externalScoredValues = ['human', 'externalMachine'];
 
 export default {
     /**
@@ -48,9 +49,15 @@ export default {
             scoreOutcome = item.getOutcomeDeclaration('SCORE');
 
         //try setting the computed normal maximum only if the processing type is known, i.e. 'templateDriven'
-        if (scoreOutcome && item.responseProcessing && item.responseProcessing.processingType === 'templateDriven') {
+        if (
+            scoreOutcome &&
+            item.responseProcessing &&
+            item.responseProcessing.processingType === 'templateDriven' &&
+            !externalScoredValues.includes(scoreOutcome.attr('externalScored'))
+        ) {
+            const interactions = item.getInteractions();
             normalMaximum = _.reduce(
-                item.getInteractions(),
+                interactions,
                 function (acc, interaction) {
                     var interactionMaxScore = interaction.getNormalMaximum();
                     if (_.isNumber(interactionMaxScore)) {
@@ -82,7 +89,6 @@ export default {
             maxScoreOutcome;
 
         //try setting the computed normal maximum only if the processing type is known, i.e. 'templateDriven'
-        const externalScoredValues = ['human', 'externalMachine'];
         if (scoreOutcome && item.responseProcessing && item.responseProcessing.processingType === 'templateDriven') {
             const interactions = item.getInteractions();
             if (externalScoredValues.includes(scoreOutcome.attr('externalScored'))) {

--- a/test/qtiItem/maxScore/data/external-scored-none.json
+++ b/test/qtiItem/maxScore/data/external-scored-none.json
@@ -1,0 +1,297 @@
+{
+    "identifier": "i654b6b0b5e16d82f276338e15208b3",
+    "serial": "item_654ce58fdf4f1377015349",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "i654b6b0b5e16d82f276338e15208b3",
+        "title": "Item 2",
+        "label": "Item 2",
+        "xml:lang": "en-US",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "2023.12",
+        "class": ""
+    },
+    "body": {
+        "serial": "container_containeritembody_654ce58fdf4e6721636620",
+        "body": "\n    <div class=\"grid-row\">\n      <div class=\"col-12\">\n        {{interaction_choiceinteraction_654ce58fdf7ee887346937}}\n      </div>\n    </div>\n    <div class=\"grid-row\">\n      <div class=\"col-12\">\n        {{interaction_choiceinteraction_654ce58fdfa2e975907677}}\n      </div>\n    </div>\n  ",
+        "elements": {
+            "interaction_choiceinteraction_654ce58fdf7ee887346937": {
+                "serial": "interaction_choiceinteraction_654ce58fdf7ee887346937",
+                "qtiClass": "choiceInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE",
+                    "shuffle": false,
+                    "maxChoices": 0,
+                    "minChoices": 0,
+                    "orientation": "vertical"
+                },
+                "debug": {
+                    "relatedItem": "item_654ce58fdf4f1377015349"
+                },
+                "choices": {
+                    "choice_simplechoice_654ce58fdf8da861467741": {
+                        "identifier": "choice_1",
+                        "serial": "choice_simplechoice_654ce58fdf8da861467741",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_1",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654ce58fdf91a920151482",
+                            "body": "choice #1",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654ce58fdf4f1377015349"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654ce58fdf4f1377015349"
+                        }
+                    },
+                    "choice_simplechoice_654ce58fdf96c579127308": {
+                        "identifier": "choice_2",
+                        "serial": "choice_simplechoice_654ce58fdf96c579127308",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_2",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654ce58fdf980910135856",
+                            "body": "choice #2",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654ce58fdf4f1377015349"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654ce58fdf4f1377015349"
+                        }
+                    },
+                    "choice_simplechoice_654ce58fdf9c4319143634": {
+                        "identifier": "choice_3",
+                        "serial": "choice_simplechoice_654ce58fdf9c4319143634",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_3",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654ce58fdf9d7158277538",
+                            "body": "choice #3",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654ce58fdf4f1377015349"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654ce58fdf4f1377015349"
+                        }
+                    }
+                },
+                "prompt": {
+                    "serial": "container_containerstatic_654ce58fdf8a3495934245",
+                    "body": "",
+                    "elements": {},
+                    "attributes": [],
+                    "debug": {
+                        "relatedItem": "item_654ce58fdf4f1377015349"
+                    }
+                }
+            },
+            "interaction_choiceinteraction_654ce58fdfa2e975907677": {
+                "serial": "interaction_choiceinteraction_654ce58fdfa2e975907677",
+                "qtiClass": "choiceInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE_1",
+                    "shuffle": false,
+                    "maxChoices": 0,
+                    "minChoices": 0,
+                    "orientation": "vertical"
+                },
+                "debug": {
+                    "relatedItem": "item_654ce58fdf4f1377015349"
+                },
+                "choices": {
+                    "choice_simplechoice_654ce58fdfa73540841463": {
+                        "identifier": "choice_4",
+                        "serial": "choice_simplechoice_654ce58fdfa73540841463",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_4",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654ce58fdfa86816730278",
+                            "body": "choice #1",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654ce58fdf4f1377015349"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654ce58fdf4f1377015349"
+                        }
+                    },
+                    "choice_simplechoice_654ce58fdfac5222674899": {
+                        "identifier": "choice_5",
+                        "serial": "choice_simplechoice_654ce58fdfac5222674899",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_5",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654ce58fdfad7133218237",
+                            "body": "choice #2",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654ce58fdf4f1377015349"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654ce58fdf4f1377015349"
+                        }
+                    },
+                    "choice_simplechoice_654ce58fdfb14767611556": {
+                        "identifier": "choice_6",
+                        "serial": "choice_simplechoice_654ce58fdfb14767611556",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_6",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654ce58fdfb26246379673",
+                            "body": "choice #3",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654ce58fdf4f1377015349"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654ce58fdf4f1377015349"
+                        }
+                    }
+                },
+                "prompt": {
+                    "serial": "container_containerstatic_654ce58fdfa65041138051",
+                    "body": "",
+                    "elements": {},
+                    "attributes": [],
+                    "debug": {
+                        "relatedItem": "item_654ce58fdf4f1377015349"
+                    }
+                }
+            }
+        },
+        "attributes": [],
+        "debug": {
+            "relatedItem": "item_654ce58fdf4f1377015349"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_654ce58fdf4f1377015349"
+    },
+    "namespaces": {
+        "": "http://www.imsglobal.org/xsd/imsqti_v2p2",
+        "m": "http://www.w3.org/1998/Math/MathML",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "schemaLocations": {
+        "http://www.imsglobal.org/xsd/imsqti_v2p2": "http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
+    },
+    "stylesheets": {},
+    "outcomes": {
+        "outcomedeclaration_654ce58fdf6c6514414636": {
+            "identifier": "OUTCOME_145",
+            "serial": "outcomedeclaration_654ce58fdf6c6514414636",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "OUTCOME_145",
+                "cardinality": "single",
+                "baseType": "float",
+                "longInterpretation": "",
+                "normalMaximum": 10,
+                "normalMinimum": 0
+            },
+            "debug": {
+                "relatedItem": "item_654ce58fdf4f1377015349"
+            },
+            "defaultValue": null
+        }
+    },
+    "responses": {
+        "responsedeclaration_654ce58fdf61c421915925": {
+            "identifier": "RESPONSE",
+            "serial": "responsedeclaration_654ce58fdf61c421915925",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE",
+                "cardinality": "multiple",
+                "baseType": "identifier"
+            },
+            "debug": {
+                "relatedItem": "item_654ce58fdf4f1377015349"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "no_response_processing",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        },
+        "responsedeclaration_654ce58fdf691820414705": {
+            "identifier": "RESPONSE_1",
+            "serial": "responsedeclaration_654ce58fdf691820414705",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE_1",
+                "cardinality": "multiple",
+                "baseType": "identifier"
+            },
+            "debug": {
+                "relatedItem": "item_654ce58fdf4f1377015349"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "no_response_processing",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        }
+    },
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_templatesdriven_654ce58fdfd48520167390",
+        "qtiClass": "responseProcessing",
+        "attributes": {},
+        "debug": {
+            "relatedItem": "item_654ce58fdf4f1377015349"
+        },
+        "processingType": "templateDriven",
+        "responseRules": []
+    },
+    "apipAccessibility": ""
+}

--- a/test/qtiItem/maxScore/data/external-scored.json
+++ b/test/qtiItem/maxScore/data/external-scored.json
@@ -1,0 +1,216 @@
+{
+    "identifier": "i654b6b0b5e16d82f276338e15208b3",
+    "serial": "item_654b94bf17fed770106184",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "i654b6b0b5e16d82f276338e15208b3",
+        "title": "Item 2",
+        "label": "Item 2",
+        "xml:lang": "en-US",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "2023.12",
+        "class": ""
+    },
+    "body": {
+        "serial": "container_containeritembody_654b94bf17fe3202964310",
+        "body": "\n    <div class=\"grid-row\">\n      <div class=\"col-12\">\n        {{interaction_choiceinteraction_654b94bf18523382256579}}\n      </div>\n    </div>\n  ",
+        "elements": {
+            "interaction_choiceinteraction_654b94bf18523382256579": {
+                "serial": "interaction_choiceinteraction_654b94bf18523382256579",
+                "qtiClass": "choiceInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE",
+                    "shuffle": false,
+                    "maxChoices": 0,
+                    "minChoices": 0,
+                    "orientation": "vertical"
+                },
+                "debug": {
+                    "relatedItem": "item_654b94bf17fed770106184"
+                },
+                "choices": {
+                    "choice_simplechoice_654b94bf186df639514672": {
+                        "identifier": "choice_1",
+                        "serial": "choice_simplechoice_654b94bf186df639514672",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_1",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654b94bf18721980542009",
+                            "body": "choice #1",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654b94bf17fed770106184"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654b94bf17fed770106184"
+                        }
+                    },
+                    "choice_simplechoice_654b94bf1877e552329948": {
+                        "identifier": "choice_2",
+                        "serial": "choice_simplechoice_654b94bf1877e552329948",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_2",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654b94bf18791597792017",
+                            "body": "choice #2",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654b94bf17fed770106184"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654b94bf17fed770106184"
+                        }
+                    },
+                    "choice_simplechoice_654b94bf18800928984637": {
+                        "identifier": "choice_3",
+                        "serial": "choice_simplechoice_654b94bf18800928984637",
+                        "qtiClass": "simpleChoice",
+                        "attributes": {
+                            "identifier": "choice_3",
+                            "fixed": false,
+                            "showHide": "show"
+                        },
+                        "body": {
+                            "serial": "container_containerstatic_654b94bf18813566963366",
+                            "body": "choice #3",
+                            "elements": {},
+                            "attributes": [],
+                            "debug": {
+                                "relatedItem": "item_654b94bf17fed770106184"
+                            }
+                        },
+                        "debug": {
+                            "relatedItem": "item_654b94bf17fed770106184"
+                        }
+                    }
+                },
+                "prompt": {
+                    "serial": "container_containerstatic_654b94bf18698457970495",
+                    "body": "",
+                    "elements": {},
+                    "attributes": [],
+                    "debug": {
+                        "relatedItem": "item_654b94bf17fed770106184"
+                    }
+                }
+            }
+        },
+        "attributes": [],
+        "debug": {
+            "relatedItem": "item_654b94bf17fed770106184"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_654b94bf17fed770106184"
+    },
+    "namespaces": {
+        "": "http://www.imsglobal.org/xsd/imsqti_v2p2",
+        "m": "http://www.w3.org/1998/Math/MathML",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "schemaLocations": {
+        "http://www.imsglobal.org/xsd/imsqti_v2p2": "http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
+    },
+    "stylesheets": {},
+    "outcomes": {
+        "outcomedeclaration_654b94bf18233488092712": {
+            "identifier": "SCORE",
+            "serial": "outcomedeclaration_654b94bf18233488092712",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "SCORE",
+                "cardinality": "single",
+                "baseType": "float",
+                "longInterpretation": "",
+                "externalScored": "human",
+                "normalMaximum": 6,
+                "normalMinimum": 0
+            },
+            "debug": {
+                "relatedItem": "item_654b94bf17fed770106184"
+            },
+            "defaultValue": null
+        },
+        "outcomedeclaration_654b94bf18321587793987": {
+            "identifier": "MAXSCORE",
+            "serial": "outcomedeclaration_654b94bf18321587793987",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "MAXSCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_654b94bf17fed770106184"
+            },
+            "defaultValue": "5"
+        },
+        "outcomedeclaration_654b94bf18355694138551": {
+            "identifier": "OUTCOME_145",
+            "serial": "outcomedeclaration_654b94bf18355694138551",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "OUTCOME_145",
+                "cardinality": "single",
+                "baseType": "float",
+                "longInterpretation": "",
+                "normalMaximum": 10,
+                "normalMinimum": 0
+            },
+            "debug": {
+                "relatedItem": "item_654b94bf17fed770106184"
+            },
+            "defaultValue": null
+        }
+    },
+    "responses": {
+        "responsedeclaration_654b94bf1819b360655406": {
+            "identifier": "RESPONSE",
+            "serial": "responsedeclaration_654b94bf1819b360655406",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE",
+                "cardinality": "multiple",
+                "baseType": "identifier"
+            },
+            "debug": {
+                "relatedItem": "item_654b94bf17fed770106184"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "no_response_processing",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        }
+    },
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_templatesdriven_654b94bf1894d572936125",
+        "qtiClass": "responseProcessing",
+        "attributes": {},
+        "debug": {
+            "relatedItem": "item_654b94bf17fed770106184"
+        },
+        "processingType": "templateDriven",
+        "responseRules": []
+    },
+    "apipAccessibility": ""
+}

--- a/test/qtiItem/maxScore/test.js
+++ b/test/qtiItem/maxScore/test.js
@@ -64,7 +64,8 @@ define([
     'json!taoQtiItem/test/qtiItem/maxScore/data/graphic-gap-infinite.json',
     'json!taoQtiItem/test/qtiItem/maxScore/data/graphic-associate-matchmax.json',
     'json!taoQtiItem/test/qtiItem/maxScore/data/response-none.json',
-    'json!taoQtiItem/test/qtiItem/maxScore/data/external-scored.json'
+    'json!taoQtiItem/test/qtiItem/maxScore/data/external-scored.json',
+    'json!taoQtiItem/test/qtiItem/maxScore/data/external-scored-none.json'
 ], function(
     _,
     Element,
@@ -114,7 +115,8 @@ define([
     dataGapMatchInfinite,
     dataGraphicAssocMatchmax,
     dataResponseNone,
-    dataResponseExternalScored
+    dataResponseExternalScored,
+    dataResponseExternalScoredNone,
 ) {
     'use strict';
 
@@ -408,7 +410,8 @@ define([
             maxScore: 5
         },
         { title: 'response - none', data: dataResponseNone, expectedMaximum: 5, maxScore: 5 },
-        { title: 'external scored', data: dataResponseExternalScored, expectedMaximum: 6, maxScore: 6 }
+        { title: 'external scored', data: dataResponseExternalScored, expectedMaximum: 6, maxScore: 6 },
+        { title: 'removed MAXSCORE and SCORE', data: dataResponseExternalScoredNone, expectedMaximum: undefined, maxScore: undefined },
     ];
 
     QUnit.cases.init(cases).test('setNormalMaximum', function(settings, assert) {
@@ -429,18 +432,20 @@ define([
 
             outcomeScore = item.getOutcomeDeclaration('SCORE');
 
-            if (outcomeScore.getAttributes()['externalScored']) {
+            if (outcomeScore && outcomeScore.getAttributes()['externalScored']) {
                 assert.ok(outcomeScore.attr('normalMaximum'), 'normalMaximum defined');
             } else {
-                assert.ok(_.isUndefined(outcomeScore.attr('normalMaximum')), 'normalMaximum initially undefined');
+                assert.ok(_.isUndefined(outcomeScore && outcomeScore.attr('normalMaximum')), 'normalMaximum initially undefined');
             }
 
             maxScore.setNormalMaximum(item);
-            assert.equal(
-                outcomeScore.attr('normalMaximum'),
-                settings.expectedMaximum,
-                'calculated normalMaximum is correct'
-            );
+            if (!_.isUndefined(settings.expectedMaximum)) {
+                assert.equal(
+                    outcomeScore.attr('normalMaximum'),
+                    settings.expectedMaximum,
+                    'calculated normalMaximum is correct'
+                );
+            }
 
             maxScore.setMaxScore(item);
             if (!_.isUndefined(settings.maxScore)) {
@@ -449,7 +454,11 @@ define([
                 assert.ok(Element.isA(outcomeMaxScore, 'outcomeDeclaration'), 'MAXSCORE outcome exists');
                 assert.equal(outcomeMaxScore.getDefaultValue(), settings.maxScore);
             } else {
-                assert.expect(4);
+                if (!_.isUndefined(settings.expectedMaximum)) {
+                    assert.expect(4);
+                } else {
+                    assert.expect(3);
+                }
                 assert.ok(_.isUndefined(item.getOutcomeDeclaration('MAXSCORE')), 'MAXSCORE undefined');
             }
         });

--- a/test/qtiItem/maxScore/test.js
+++ b/test/qtiItem/maxScore/test.js
@@ -63,7 +63,8 @@ define([
     'json!taoQtiItem/test/qtiItem/maxScore/data/gapmatch-map-matchmax.json',
     'json!taoQtiItem/test/qtiItem/maxScore/data/graphic-gap-infinite.json',
     'json!taoQtiItem/test/qtiItem/maxScore/data/graphic-associate-matchmax.json',
-    'json!taoQtiItem/test/qtiItem/maxScore/data/response-none.json'
+    'json!taoQtiItem/test/qtiItem/maxScore/data/response-none.json',
+    'json!taoQtiItem/test/qtiItem/maxScore/data/external-scored.json'
 ], function(
     _,
     Element,
@@ -112,7 +113,8 @@ define([
     dataGapMatchMapMatchmax,
     dataGapMatchInfinite,
     dataGraphicAssocMatchmax,
-    dataResponseNone
+    dataResponseNone,
+    dataResponseExternalScored
 ) {
     'use strict';
 
@@ -406,6 +408,7 @@ define([
             maxScore: 5
         },
         { title: 'response - none', data: dataResponseNone, expectedMaximum: 5, maxScore: 5 },
+        { title: 'external scored', data: dataResponseExternalScored, expectedMaximum: 6, maxScore: 6 }
     ];
 
     QUnit.cases.init(cases).test('setNormalMaximum', function(settings, assert) {


### PR DESCRIPTION
Tickets: 
- https://oat-sa.atlassian.net/browse/AUT-3353
- https://oat-sa.atlassian.net/browse/AUT-3354

## What's Changed

- `MAXSCORE` value has been set to the `SCORE` upper bound value in case it is configured with `externalScored` set to `Human` or `External Machine`.
- In case defined `SCORE` the custom `Outcome Declarations` values are ignored.
- Authoring UI deletes the SCORE and MAXSCORE outcome variables when all interactions are configured with none response processing rule, and the externalScored property of the SCORE variable is set to None

## How to test
- Create a test item with some interactions
- Switch `Response processing` to none
- Set up `Outcome Declarations` `SCORE` option and choose the value's range
- Save the item
- Go to item preview
- Submit the test
- The `MAXSCORE` should be equal to the upper bound value of `SCORE` outcome
- Set up response processing rule to `none`
- Set externalScored property of the `SCORE` to `none`
- Save the item
- Check `SCORE` and `MAXSCORE` outcome variables are deleted