### PR TITLE
[INF-227] Even if "integer" is set as Response base type in the response, a float can be entered in the correct answer setting and in the answer.

### DIFF
--- a/src/qtiCommonRenderer/helpers/textEntryConverterHelper.js
+++ b/src/qtiCommonRenderer/helpers/textEntryConverterHelper.js
@@ -1,0 +1,36 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019-2023 Open Assessment Technologies SA ;
+ */
+import locale from 'util/locale';
+import converter from 'util/converter';
+
+export default function textEntryConverterHelper(value, attributes) {
+    const numericBase = attributes.base || 10;
+    const convertedValue = converter.convert(value.trim());
+    switch (attributes.baseType) {
+        case 'integer':
+            value = locale.parseInt(convertedValue, numericBase);
+            return isNaN(value) ? '' : value;
+        case 'float':
+            value = locale.parseFloat(convertedValue);
+            return isNaN(value) ? '' : value;
+        case 'string':
+            return convertedValue;
+        default:
+            return ''; // all unparsable values returns as empty string
+    }
+}

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -28,14 +28,12 @@ import _ from 'lodash';
 import __ from 'i18n';
 import tpl from 'taoQtiItem/qtiCommonRenderer/tpl/interactions/textEntryInteraction';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
-import textEntryConverterHelper from 'taoQtiItem/qtiCreator/helper/textEntryConverterHelper';
+import textEntryConverterHelper from 'taoQtiItem/qtiCommonRenderer/helper/textEntryConverterHelper';
 import instructionMgr from 'taoQtiItem/qtiCommonRenderer/helpers/instructions/instructionManager';
 import pciResponse from 'taoQtiItem/qtiCommonRenderer/helpers/PciResponse';
 import patternMaskHelper from 'taoQtiItem/qtiCommonRenderer/helpers/patternMask';
-import locale from 'util/locale';
 import tooltip from 'ui/tooltip';
 import loggerFactory from 'core/logger';
-import converter from 'util/converter';
 
 /**
  * Create a logger
@@ -184,9 +182,9 @@ function render(interaction) {
                 containerHelper.triggerResponseChangeEvent(interaction);
             })
             .on('blur.commonRenderer', function () {
+                hideTooltip($input);
                 $input.removeClass('invalid');
                 const value = textEntryConverterHelper($input.val(), {...attributes, baseType});
-                $input.val(value);
                 if (value === '') {
                     $input.addClass('invalid');
                     showTooltip($input, 'error', __('This is not a valid answer'));

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -245,7 +245,8 @@ function getResponse(interaction) {
         const convertedValue = converter.convert(inputValue.trim());
         if (baseType === 'integer') {
             value = locale.parseInt(convertedValue, numericBase);
-            $input.val(value);
+            // restrict user to input anything except integers
+            $input.val(isNaN(value) ? '' : value);
         } else if (baseType === 'float') {
             value = locale.parseFloat(convertedValue);
         } else if (baseType === 'string') {

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -28,7 +28,7 @@ import _ from 'lodash';
 import __ from 'i18n';
 import tpl from 'taoQtiItem/qtiCommonRenderer/tpl/interactions/textEntryInteraction';
 import containerHelper from 'taoQtiItem/qtiCommonRenderer/helpers/container';
-import textEntryConverterHelper from 'taoQtiItem/qtiCommonRenderer/helper/textEntryConverterHelper';
+import textEntryConverterHelper from 'taoQtiItem/qtiCommonRenderer/helpers/textEntryConverterHelper';
 import instructionMgr from 'taoQtiItem/qtiCommonRenderer/helpers/instructions/instructionManager';
 import pciResponse from 'taoQtiItem/qtiCommonRenderer/helpers/PciResponse';
 import patternMaskHelper from 'taoQtiItem/qtiCommonRenderer/helpers/patternMask';

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -187,7 +187,7 @@ function render(interaction) {
                 const value = textEntryConverterHelper($input.val(), {...attributes, baseType});
                 if (value === '') {
                     $input.addClass('invalid');
-                    showTooltip($input, 'error', __('This is not a valid answer'));
+                    showTooltip($input, 'error', __('This is not a valid answer. Expected %s', baseType));
                 }
             });
     }

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -245,6 +245,7 @@ function getResponse(interaction) {
         const convertedValue = converter.convert(inputValue.trim());
         if (baseType === 'integer') {
             value = locale.parseInt(convertedValue, numericBase);
+            $input.val(value);
         } else if (baseType === 'float') {
             value = locale.parseFloat(convertedValue);
         } else if (baseType === 'string') {


### PR DESCRIPTION
Ticket: <a class="link" href='https://oat-sa.atlassian.net/browse/INF-227'>INF-227</a>

## What's Changed

- Fixed the possibility to enter the float nuber in integer text interaction type

## Demo
![image](https://i.imgur.com/0DEYQfP.gif)

## How to test
Deployed on [kitchen](http://test-kiril.playground.kitchen.it.taocloud.org:40351/)
- Create a test with an item with a Text Entry interaction with Response base type set as integer.
- Launch the test and enter a float number (for example 3.14)