### PR TITLE
fix: where to filter in lodash 4

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/GraphicOrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/GraphicOrderInteraction.js
@@ -303,7 +303,7 @@ const setResponse = function (interaction, response) {
 
                 //get the choice that match the response
                 const choice = _(interaction.getChoices())
-                    .where({ attributes: { identifier: responseValue } })
+                    .filter({ attributes: { identifier: responseValue } })
                     .first();
                 if (choice) {
                     const element = interaction.paper.getById(choice.serial);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-3541

**Problem**
Console errors in Graphic Order appeared because of using the `where` function in lodash 4.

**Changes Made**
Replaced instance of `_.where` with `_.filter` 