### PR TITLE
fix: expose zero maxscore for upload and endAttempt interactions

### DIFF
--- a/src/qtiItem/core/interactions/EndAttemptInteraction.js
+++ b/src/qtiItem/core/interactions/EndAttemptInteraction.js
@@ -1,4 +1,7 @@
 import InlineInteraction from 'taoQtiItem/qtiItem/core/interactions/InlineInteraction';
 export default InlineInteraction.extend({
-    qtiClass: 'endAttemptInteraction'
+    qtiClass: 'endAttemptInteraction',
+    getNormalMaximum() {
+        return 0;
+    }
 });

--- a/src/qtiItem/core/interactions/UploadInteraction.js
+++ b/src/qtiItem/core/interactions/UploadInteraction.js
@@ -1,5 +1,8 @@
 import InlineInteraction from 'taoQtiItem/qtiItem/core/interactions/BlockInteraction';
 var UploadInteraction = InlineInteraction.extend({
-    qtiClass: 'uploadInteraction'
+    qtiClass: 'uploadInteraction',
+    getNormalMaximum() {
+        return 0;
+    }
 });
 export default UploadInteraction;

--- a/test/qtiItem/maxScore/test.js
+++ b/test/qtiItem/maxScore/test.js
@@ -221,14 +221,14 @@ define([
             expectedMaximum: 1,
             maxScore: 4
         },
-        { title: 'upload', data: dataUpload, expectedMaximum: undefined, maxScore: undefined },
+        { title: 'upload', data: dataUpload, expectedMaximum: 0, maxScore: 0 },
         { title: 'custom interaction', data: dataPci, expectedMaximum: 0, maxScore: 0 },
         { title: 'custom response processing', data: dataCustomRp, expectedMaximum: undefined, maxScore: undefined },
         {
             title: 'upload and choice - correct',
             data: dataUploadChoice,
-            expectedMaximum: undefined,
-            maxScore: undefined
+            expectedMaximum: 0,
+            maxScore: 0
         },
         { title: 'hottext - correct', data: dataHottextCorrect, expectedMaximum: 1, maxScore: 1 },
         { title: 'hotspot - correct', data: dataHotspotCorrect, expectedMaximum: 1, maxScore: 1 },


### PR DESCRIPTION
Tickets:
https://oat-sa.atlassian.net/browse/AUT-2604,
https://oat-sa.atlassian.net/browse/AUT-3593

## What's Changed

- Exposed normal maximum as zero for the EndAttemptInteraction and UploadInteraction
- It will be considered during maxscore calculation for the test item 
and prevent removing the maxscore outcome variable from the item

## How to test
- Create a new item
- DnD a Choice Interaction
- Save the item
- DnD “End attempt“ Interaction
- Save the Item 
- Preview the Item and click "Submit"
- Check both the MAXSCORE and SCORE outcomes are present
- Repeat this flow with "File Upload" interaction

**Available for test on**: http://test-viktar-2.playground.kitchen.it.taocloud.org:42481/
