### PR TITLE
feat: Add tooltip for wrong decimal format in Text Entry

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -82,14 +82,18 @@ function showTooltip($input, theme, message) {
  * @param {jQuery} $input
  */
 function validateDecimalInput ($input) {
-    const value = $input.val();
+    const value = converter.convert($input.val());
     const thousandsSeparator = locale.getThousandsSeparator();
     const decimalSeparator = locale.getDecimalSeparator();
-    const negativeSigns = '\u002D\u2212\u2010\u8213';
 
-    const regex = thousandsSeparator
-        ? new RegExp(`^$|^[-${negativeSigns}]?\\d{1,3}(${thousandsSeparator}\\d{3})*(${decimalSeparator}\\d+)?$|^[-${negativeSigns}]?\\d+(${decimalSeparator}\\d+)?$|^[-${negativeSigns}]?\\d*${decimalSeparator}$|^[-${negativeSigns}]?${decimalSeparator}\\d+$`)
-        : new RegExp(`^$|^[-${negativeSigns}]?\\d+(${decimalSeparator}\\d+)?$|^[-${negativeSigns}]?\\d*${decimalSeparator}$|^[-${negativeSigns}]?${decimalSeparator}\\d+$`);
+    const escapedThousandsSeparator = thousandsSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedDecimalSeparator = decimalSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    const regexPattern = thousandsSeparator
+        ? `^$|^-?\\d{1,3}(${escapedThousandsSeparator}\\d{3})*(${escapedDecimalSeparator}\\d+)?$|^-?\\d+(${escapedDecimalSeparator}\\d+)?$|^-?\\d*${escapedDecimalSeparator}$|^-?${escapedDecimalSeparator}\\d+$`
+        : `^$|^-?\\d+(${escapedDecimalSeparator}\\d+)?$|^-?\\d*${escapedDecimalSeparator}$|^-?${escapedDecimalSeparator}\\d+$`;
+
+    const regex = new RegExp(regexPattern);
 
     if (!regex.test(value)) {
         $input.addClass('invalid');
@@ -128,9 +132,9 @@ function render(interaction) {
         case 'float':
             $input.attr('inputmode', 'decimal');
 
-            $input.on('keyup.decimalValidation', () => validateDecimalInput($input))
-                .on('focus.decimalValidation', () => validateDecimalInput($input))
-                .on('blur.decimalValidation', () => hideTooltip($input));
+            $input.on('keyup.commonRenderer', () => validateDecimalInput($input))
+                .on('focus.commonRenderer', () => validateDecimalInput($input))
+                .on('blur.commonRenderer', () => hideTooltip($input));
             break;
         default:
             $input.attr('inputmode', 'text');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -99,8 +99,8 @@ function validateDecimalInput ($input) {
         $input.addClass('invalid');
         $input.addClass('error');
         const decimalError = thousandsSeparator
-            ? __('Invalid value, use . (dot) for decimal point and , (comma) for thousands separator.')
-            : __('Invalid value, use . (dot) for decimal point.');
+            ? __('Invalid value, use %s (dot) for decimal point and %s (comma) for thousands separator.', decimalSeparator, thousandsSeparator)
+            : __('Invalid value, use %s (dot) for decimal point.', decimalSeparator);
         showTooltip($input, 'error', decimalError);
     } else {
         $input.removeClass('invalid');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -73,6 +73,29 @@ function showTooltip($input, theme, message) {
 }
 
 /**
+ * Validate the input for decimal values.
+ *
+ * This function ensures that the input value is either empty or follows
+ * the rules for decimal numbers. It allows numbers with optional
+ * thousands separators (commas) and a mandatory decimal point (dot).
+ *
+ * @param {jQuery} $input
+ */
+function validateDecimalInput ($input) {
+    const value = $input.val();
+    const regex = /^$|^-?\d{1,3}(,\d{3})*(\.\d+)?$|^-?\d+(\.\d+)?$|^-?\d*\.$|^-?\.\d+$/;
+    if (!regex.test(value)) {
+        $input.addClass('invalid');
+        $input.css('border-color', 'red');
+        showTooltip($input, 'error', __('Invalid value, use . (dot) for decimal point and , (comma) for thousands separator.'));
+    } else {
+        $input.removeClass('invalid');
+        $input.css('border-color', '');
+        hideTooltip($input);
+    }
+}
+
+/**
  * Init rendering, called after template injected into the DOM
  * All options are listed in the QTI v2.1 information model:
  * http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10333
@@ -94,6 +117,10 @@ function render(interaction) {
             break;
         case 'float':
             $input.attr('inputmode', 'decimal');
+
+            $input.on('keyup.decimalValidation', () => validateDecimalInput($input))
+                .on('focus.decimalValidation', () => validateDecimalInput($input))
+                .on('blur.decimalValidation', () => hideTooltip($input));
             break;
         default:
             $input.attr('inputmode', 'text');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -86,11 +86,11 @@ function validateDecimalInput ($input) {
     const regex = /^$|^-?\d{1,3}(,\d{3})*(\.\d+)?$|^-?\d+(\.\d+)?$|^-?\d*\.$|^-?\.\d+$/;
     if (!regex.test(value)) {
         $input.addClass('invalid');
-        $input.css('border-color', 'red');
+        $input.addClass('error');
         showTooltip($input, 'error', __('Invalid value, use . (dot) for decimal point and , (comma) for thousands separator.'));
     } else {
         $input.removeClass('invalid');
-        $input.css('border-color', '');
+        $input.removeClass('error');
         hideTooltip($input);
     }
 }

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -83,7 +83,8 @@ function showTooltip($input, theme, message) {
  */
 function validateDecimalInput ($input) {
     const value = $input.val();
-    const regex = /^$|^-?\d{1,3}(,\d{3})*(\.\d+)?$|^-?\d+(\.\d+)?$|^-?\d*\.$|^-?\.\d+$/;
+    const negativeSigns = '\u002D\u2212\u2010\u8213';
+    const regex = new RegExp(`^$|^[-${negativeSigns}]?\\d{1,3}(,\\d{3})*(\\.\\d+)?$|^[-${negativeSigns}]?\\d+(\\.\\d+)?$|^[-${negativeSigns}]?\\d*\\.$|^[-${negativeSigns}]?\\.\\d+$`);
     if (!regex.test(value)) {
         $input.addClass('invalid');
         $input.addClass('error');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -83,8 +83,14 @@ function showTooltip($input, theme, message) {
  */
 function validateDecimalInput ($input) {
     const value = $input.val();
+    const thousandsSeparator = locale.getThousandsSeparator();
+    const decimalSeparator = locale.getDecimalSeparator();
     const negativeSigns = '\u002D\u2212\u2010\u8213';
-    const regex = new RegExp(`^$|^[-${negativeSigns}]?\\d{1,3}(,\\d{3})*(\\.\\d+)?$|^[-${negativeSigns}]?\\d+(\\.\\d+)?$|^[-${negativeSigns}]?\\d*\\.$|^[-${negativeSigns}]?\\.\\d+$`);
+
+    const regex = thousandsSeparator
+        ? new RegExp(`^$|^[-${negativeSigns}]?\\d{1,3}(${thousandsSeparator}\\d{3})*(${decimalSeparator}\\d+)?$|^[-${negativeSigns}]?\\d+(${decimalSeparator}\\d+)?$|^[-${negativeSigns}]?\\d*${decimalSeparator}$|^[-${negativeSigns}]?${decimalSeparator}\\d+$`)
+        : new RegExp(`^$|^[-${negativeSigns}]?\\d+(${decimalSeparator}\\d+)?$|^[-${negativeSigns}]?\\d*${decimalSeparator}$|^[-${negativeSigns}]?${decimalSeparator}\\d+$`);
+
     if (!regex.test(value)) {
         $input.addClass('invalid');
         $input.addClass('error');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -82,9 +82,15 @@ function showTooltip($input, theme, message) {
  * @param {jQuery} $input
  */
 function validateDecimalInput ($input) {
+    const separatorName = {
+        '.': __('(dot)'),
+        ',': __('(comma)')
+    };
     const value = converter.convert($input.val());
     const thousandsSeparator = locale.getThousandsSeparator();
     const decimalSeparator = locale.getDecimalSeparator();
+    const thousandsSeparatorName = separatorName[thousandsSeparator] ?? '';
+    const decimalSeparatorName = separatorName[decimalSeparator] ?? '';
 
     const escapedThousandsSeparator = thousandsSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const escapedDecimalSeparator = decimalSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -99,8 +105,8 @@ function validateDecimalInput ($input) {
         $input.addClass('invalid');
         $input.addClass('error');
         const decimalError = thousandsSeparator
-            ? __('Invalid value, use %s (dot) for decimal point and %s (comma) for thousands separator.', decimalSeparator, thousandsSeparator)
-            : __('Invalid value, use %s (dot) for decimal point.', decimalSeparator);
+            ? __('Invalid value, use %s %s for decimal point and %s %s for thousands separator.', decimalSeparator, decimalSeparatorName, thousandsSeparator, thousandsSeparatorName)
+            : __('Invalid value, use %s %s for decimal point.', decimalSeparator, decimalSeparatorName);
         showTooltip($input, 'error', decimalError);
     } else {
         $input.removeClass('invalid');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -94,7 +94,10 @@ function validateDecimalInput ($input) {
     if (!regex.test(value)) {
         $input.addClass('invalid');
         $input.addClass('error');
-        showTooltip($input, 'error', __('Invalid value, use . (dot) for decimal point and , (comma) for thousands separator.'));
+        const decimalError = thousandsSeparator
+            ? __('Invalid value, use . (dot) for decimal point and , (comma) for thousands separator.')
+            : __('Invalid value, use . (dot) for decimal point.');
+        showTooltip($input, 'error', decimalError);
     } else {
         $input.removeClass('invalid');
         $input.removeClass('error');

--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -81,7 +81,7 @@ function showTooltip($input, theme, message) {
  *
  * @param {jQuery} $input
  */
-function validateDecimalInput ($input) {
+function validateDecimalInput($input) {
     const separatorName = {
         '.': __('(dot)'),
         ',': __('(comma)')
@@ -89,8 +89,8 @@ function validateDecimalInput ($input) {
     const value = converter.convert($input.val());
     const thousandsSeparator = locale.getThousandsSeparator();
     const decimalSeparator = locale.getDecimalSeparator();
-    const thousandsSeparatorName = separatorName[thousandsSeparator] ?? '';
-    const decimalSeparatorName = separatorName[decimalSeparator] ?? '';
+    const thousandsSeparatorName = separatorName[thousandsSeparator] ? separatorName[thousandsSeparator] : '';
+    const decimalSeparatorName = separatorName[decimalSeparator] ? separatorName[decimalSeparator] : '';
 
     const escapedThousandsSeparator = thousandsSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const escapedDecimalSeparator = decimalSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -105,7 +105,13 @@ function validateDecimalInput ($input) {
         $input.addClass('invalid');
         $input.addClass('error');
         const decimalError = thousandsSeparator
-            ? __('Invalid value, use %s %s for decimal point and %s %s for thousands separator.', decimalSeparator, decimalSeparatorName, thousandsSeparator, thousandsSeparatorName)
+            ? __(
+                  'Invalid value, use %s %s for decimal point and %s %s for thousands separator.',
+                  decimalSeparator,
+                  decimalSeparatorName,
+                  thousandsSeparator,
+                  thousandsSeparatorName
+              )
             : __('Invalid value, use %s %s for decimal point.', decimalSeparator, decimalSeparatorName);
         showTooltip($input, 'error', decimalError);
     } else {
@@ -138,7 +144,8 @@ function render(interaction) {
         case 'float':
             $input.attr('inputmode', 'decimal');
 
-            $input.on('keyup.commonRenderer', () => validateDecimalInput($input))
+            $input
+                .on('keyup.commonRenderer', () => validateDecimalInput($input))
                 .on('focus.commonRenderer', () => validateDecimalInput($input))
                 .on('blur.commonRenderer', () => hideTooltip($input));
             break;
@@ -187,14 +194,14 @@ function render(interaction) {
 
         $input
             .attr('maxlength', maxChars)
-            .on('focus.commonRenderer', function() {
+            .on('focus.commonRenderer', function () {
                 updateMaxCharsTooltip();
             })
-            .on('keyup.commonRenderer', function() {
+            .on('keyup.commonRenderer', function () {
                 updateMaxCharsTooltip();
                 containerHelper.triggerResponseChangeEvent(interaction);
             })
-            .on('blur.commonRenderer', function() {
+            .on('blur.commonRenderer', function () {
                 hideTooltip($input);
             });
     } else if (attributes.patternMask) {
@@ -214,18 +221,18 @@ function render(interaction) {
         };
 
         $input
-            .on('focus.commonRenderer', function() {
+            .on('focus.commonRenderer', function () {
                 updatePatternMaskTooltip();
             })
-            .on('keyup.commonRenderer', function() {
+            .on('keyup.commonRenderer', function () {
                 updatePatternMaskTooltip();
                 containerHelper.triggerResponseChangeEvent(interaction);
             })
-            .on('blur.commonRenderer', function() {
+            .on('blur.commonRenderer', function () {
                 hideTooltip($input);
             });
     } else {
-        $input.on('keyup.commonRenderer', function() {
+        $input.on('keyup.commonRenderer', function () {
             containerHelper.triggerResponseChangeEvent(interaction);
         });
     }
@@ -305,7 +312,7 @@ function getResponse(interaction) {
 }
 
 function destroy(interaction) {
-    $('input.qti-textEntryInteraction').each(function(index, el) {
+    $('input.qti-textEntryInteraction').each(function (index, el) {
         const $input = $(el);
         if ($input.data('$tooltip')) {
             $input.data('$tooltip').dispose();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-6116

When the Text Entry input field is blurred:

A red border to the input is displayed.

A tooltip is displayed above the input, mentioning the accepted number format for the input (adapted for configured decimalSeparator and thousandsSeparator), for example Invalid value, use . (dot) for decimal point and , (comma) for thousands separator.
<img width="304" alt="Zrzut ekranu 2024-05-22 o 08 02 02" src="https://github.com/oat-sa/tao-item-runner-qti-fe/assets/133767102/c1a1fbaa-1fe4-415b-83e8-619c4cddb1b7">
<img width="223" alt="Zrzut ekranu 2024-05-22 o 08 02 36" src="https://github.com/oat-sa/tao-item-runner-qti-fe/assets/133767102/b04f342a-ddb2-40e3-b4b4-62016688d26a">
The value is still truncated if submitted as an invalid value.