### PR TITLE
fix: send decimal value if is wrong format

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/TextEntryInteraction.js
@@ -103,7 +103,6 @@ function validateDecimalInput($input) {
     const regex = new RegExp(regexPattern);
 
     if (!regex.test(value)) {
-        $input.addClass('invalid');
         $input.addClass('error');
         const decimalError = thousandsSeparator
             ? __(
@@ -116,7 +115,6 @@ function validateDecimalInput($input) {
             : __('Invalid value, use %s %s for decimal point.', decimalSeparator, decimalSeparatorName);
         showTooltip($input, 'error', decimalError);
     } else {
-        $input.removeClass('invalid');
         $input.removeClass('error');
         hideTooltip($input);
     }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-6116

After implementing decimal validation, in cases of incorrect format, no value was sent. The 'invalid' class on the input prevented data from being taken from the input, which caused the errors. Removing the 'invalid' class and leaving the 'error' class for correct CSS styling was the solution for this bug.


https://github.com/oat-sa/tao-item-runner-qti-fe/assets/133767102/d5dfbea0-ac53-4d8c-af04-d13c3b1db25e

