### PR TITLE
[AUT-3670] fix: removing hb special symbols around placeholder

### DIFF
--- a/src/qtiItem/core/Container.js
+++ b/src/qtiItem/core/Container.js
@@ -129,7 +129,7 @@ var Container = Element.extend({
                 } else {
                     tpl = tpl
                         .replace(elt.placeholder(), serial)
-                        .replace('{', '&lcub;')
+                        .replace(new RegExp(`{${serial}`), `&lcub;${serial}`)
                         .replace(serial, '{{{' + serial + '}}}');
                     elementsData[serial] = elt.render(renderer);
                 }

--- a/src/qtiItem/core/Container.js
+++ b/src/qtiItem/core/Container.js
@@ -127,7 +127,10 @@ var Container = Element.extend({
                     //@todo : container rendering merging, to be tested
                     tpl = tpl.replace(elt.placeholder(), elt.render(renderer));
                 } else {
-                    tpl = tpl.replace(elt.placeholder(), '{{{' + serial + '}}}');
+                    tpl = tpl
+                        .replace(elt.placeholder(), serial)
+                        .replace('{', '&lcub;')
+                        .replace(serial, '{{{' + serial + '}}}');
                     elementsData[serial] = elt.render(renderer);
                 }
             } else {


### PR DESCRIPTION
Ticket: [AUT-3670](https://oat-sa.atlassian.net/browse/AUT-3670)

## What's Changed

- Fixed the saving of item interaction when it have curly braces around placeholder

## Demo
![image](https://i.imgur.com/tPEjQxU.gif)

## Env
http://test-kiril.playground.kitchen.it.taocloud.org:40351/tao/Main/login
admin/admin


[AUT-3670]: https://oat-sa.atlassian.net/browse/AUT-3670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ