### PR TITLE
fix: rules for deleting SCORE and MAXSCORE outcomes

### DIFF
--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -87,6 +87,17 @@ export default {
             maxScore,
             maxScoreOutcome;
 
+        if (!scoreOutcome) {
+            // add new score outcome if not already defined
+            scoreOutcome = item.createOutcomeDeclaration({
+                cardinality: 'single',
+                baseType: 'float',
+                normalMinimum: 0.0,
+                normalMaximum: 0.0
+            });
+
+            scoreOutcome.buildIdentifier('SCORE', false);
+        }
         const customOutcomes = _(item.getOutcomes()).filter(function (outcome) {
             return outcome.id() !== 'SCORE' && outcome.id() !== 'MAXSCORE';
         });

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -44,7 +44,7 @@ export default {
      * Set the normal maximum to the item
      * @param {Object} item - the standard qti item model object
      */
-    setNormalMaximum: function setNormalMaximum(item) {
+    setNormalMaximum(item) {
         var normalMaximum,
             scoreOutcome = item.getOutcomeDeclaration('SCORE');
 
@@ -81,13 +81,15 @@ export default {
      * Set the maximum score of the item
      * @param {Object} item - the standard qti item model object
      */
-    setMaxScore: function setMaxScore(item) {
+    setMaxScore(item) {
         var hasInvalidInteraction = false,
             scoreOutcome = item.getOutcomeDeclaration('SCORE'),
-            customOutcomes,
             maxScore,
             maxScoreOutcome;
 
+        const customOutcomes = _(item.getOutcomes()).filter(function (outcome) {
+            return outcome.id() !== 'SCORE' && outcome.id() !== 'MAXSCORE';
+        });
         //try setting the computed normal maximum only if the processing type is known, i.e. 'templateDriven'
         if (scoreOutcome && item.responseProcessing && item.responseProcessing.processingType === 'templateDriven') {
             const interactions = item.getInteractions();
@@ -107,9 +109,6 @@ export default {
                     },
                     0
                 );
-                customOutcomes = _(item.getOutcomes()).filter(function (outcome) {
-                    return outcome.id() !== 'SCORE' && outcome.id() !== 'MAXSCORE';
-                });
 
                 if (customOutcomes.size()) {
                     maxScore = customOutcomes.reduce(function (acc, outcome) {
@@ -150,9 +149,12 @@ export default {
                 const template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
                 return template !== 'NONE';
             });
+            const outcomesWithExternalScored = customOutcomes.filter(outcome => {
+                return externalScoredValues.includes(outcome.attr('externalScored'));
+            });
             // remove MAXSCORE and SCORE outcome variables when all interactions are configured with none response processing rule,
             // and the externalScored property of the SCORE variable is set to None
-            if (!scoreOutcome.attr('externalScored') && isAllResponseProcessingRulesNone) {
+            if (!scoreOutcome.attr('externalScored') && isAllResponseProcessingRulesNone && outcomesWithExternalScored.size() === 0) {
                 item.removeOutcome('MAXSCORE');
                 item.removeOutcome('SCORE');
             }
@@ -164,7 +166,7 @@ export default {
      * @param {Array} choiceCollection
      * @returns {Array}
      */
-    getMatchMaxOrderedChoices: function getMatchMaxOrderedChoices(choiceCollection) {
+    getMatchMaxOrderedChoices(choiceCollection) {
         return _(choiceCollection)
             .map(function (choice) {
                 var matchMax = parseInt(choice.attr('matchMax'), 10);
@@ -186,7 +188,7 @@ export default {
      * @param {Object} interaction - a standard interaction model object
      * @returns {Number}
      */
-    choiceInteractionBased: function choiceInteractionBased(interaction, options) {
+    choiceInteractionBased(interaction, options) {
         var responseDeclaration = interaction.getResponseDeclaration();
         var mapDefault = parseFloat(responseDeclaration.mappingAttributes.defaultValue || 0);
         var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
@@ -296,7 +298,7 @@ export default {
      * @param {Object} interaction - a standard interaction model object
      * @returns {Number}
      */
-    orderInteractionBased: function orderInteractionBased(interaction) {
+    orderInteractionBased(interaction) {
         var minChoice = _ignoreMinChoice ? 0 : parseInt(interaction.attr('minChoices') || 0, 10);
         var maxChoice = parseInt(interaction.attr('maxChoices') || 0, 10);
         var responseDeclaration = interaction.getResponseDeclaration();
@@ -340,7 +342,7 @@ export default {
      * @param {Object} interaction - a standard interaction model object
      * @returns {Number}
      */
-    associateInteractionBased: function associateInteractionBased(interaction, options) {
+    associateInteractionBased(interaction, options) {
         var responseDeclaration = interaction.getResponseDeclaration();
         var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
         var maxAssoc = parseInt(interaction.attr('maxAssociations') || 0, 10);
@@ -526,7 +528,7 @@ export default {
      * @param {Object} interaction - a standard interaction model object
      * @returns {Number}
      */
-    gapMatchInteractionBased: function gapMatchInteractionBased(interaction) {
+    gapMatchInteractionBased(interaction) {
         var responseDeclaration = interaction.getResponseDeclaration();
         var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
         var maxAssoc = 0;
@@ -720,7 +722,7 @@ export default {
      * @param {Object} interaction - a standard interaction model object
      * @returns {Number}
      */
-    selectPointInteractionBased: function selectPointInteractionBased(interaction) {
+    selectPointInteractionBased(interaction) {
         var maxChoice = parseInt(interaction.attr('maxChoices'), 10);
         var minChoice = _ignoreMinChoice ? 0 : parseInt(interaction.attr('minChoices'), 10);
         var responseDeclaration = interaction.getResponseDeclaration();
@@ -771,7 +773,7 @@ export default {
      * @param {Object} interaction - a standard interaction model object
      * @returns {Number}
      */
-    sliderInteractionBased: function sliderInteractionBased(interaction) {
+    sliderInteractionBased(interaction) {
         var responseDeclaration = interaction.getResponseDeclaration();
         var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
         var max, scoreMaps;
@@ -819,7 +821,7 @@ export default {
      * @param {Object} interaction - a standard interaction model object
      * @returns {Number}
      */
-    textEntryInteractionBased: function textEntryInteractionBased(interaction) {
+    textEntryInteractionBased(interaction) {
         var responseDeclaration = interaction.getResponseDeclaration();
         var template = responseHelper.getTemplateNameFromUri(responseDeclaration.template);
         var max, scoreMaps;

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -89,13 +89,13 @@ export default {
 
         if (!scoreOutcome) {
             // add new score outcome if not already defined
-            scoreOutcome = item.createOutcomeDeclaration({
+            scoreOutcome = new OutcomeDeclaration({
                 cardinality: 'single',
                 baseType: 'float',
                 normalMinimum: 0.0,
                 normalMaximum: 0.0
             });
-
+            item.addOutcomeDeclaration(scoreOutcome);
             scoreOutcome.buildIdentifier('SCORE', false);
         }
         const customOutcomes = _(item.getOutcomes()).filter(function (outcome) {

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -154,6 +154,7 @@ export default {
             });
             // remove MAXSCORE and SCORE outcome variables when all interactions are configured with none response processing rule,
             // and the externalScored property of the SCORE variable is set to None
+            // and there are no other outcome variables with externalScored property set to human or externalMachine
             if (!scoreOutcome.attr('externalScored') && isAllResponseProcessingRulesNone && outcomesWithExternalScored.size() === 0) {
                 item.removeOutcome('MAXSCORE');
                 item.removeOutcome('SCORE');

--- a/test/qtiItem/maxScore/data/external-scored-outcome.json
+++ b/test/qtiItem/maxScore/data/external-scored-outcome.json
@@ -1,0 +1,207 @@
+{
+    "identifier": "i666ac8acca467202406131223408054",
+    "serial": "item_666ad7e04dbfa162481935",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "i666ac8acca467202406131223408054",
+        "title": "Item 3",
+        "label": "Item 3",
+        "xml:lang": "en-US",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "2024.06",
+        "class": ""
+    },
+    "body": {
+        "serial": "container_containeritembody_666ad7e04dbbd649916256",
+        "body": "\n    <div class=\"grid-row\">\n      <div class=\"col-12\">\n        {{interaction_hottextinteraction_666ad7e0509e0038016277}}\n      <\/div>\n    <\/div>\n    <div class=\"grid-row\">\n      <div class=\"col-12\">\n        {{interaction_hottextinteraction_666ad7e051230989121581}}\n      <\/div>\n    <\/div>\n  ",
+        "elements": {
+            "interaction_hottextinteraction_666ad7e0509e0038016277": {
+                "serial": "interaction_hottextinteraction_666ad7e0509e0038016277",
+                "qtiClass": "hottextInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE",
+                    "maxChoices": 0,
+                    "minChoices": 0
+                },
+                "body": {
+                    "serial": "container_containerhottext_666ad7e050d89560168530",
+                    "body": "\n          <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...<\/p>\n        ",
+                    "elements": {},
+                    "attributes": [],
+                    "debug": {
+                        "relatedItem": "item_666ad7e04dbfa162481935"
+                    }
+                },
+                "debug": {
+                    "relatedItem": "item_666ad7e04dbfa162481935"
+                },
+                "prompt": {
+                    "serial": "container_containerstatic_666ad7e050d44698016231",
+                    "body": "",
+                    "elements": {},
+                    "attributes": [],
+                    "debug": {
+                        "relatedItem": "item_666ad7e04dbfa162481935"
+                    }
+                }
+            },
+            "interaction_hottextinteraction_666ad7e051230989121581": {
+                "serial": "interaction_hottextinteraction_666ad7e051230989121581",
+                "qtiClass": "hottextInteraction",
+                "attributes": {
+                    "responseIdentifier": "RESPONSE_1",
+                    "maxChoices": 0,
+                    "minChoices": 0
+                },
+                "body": {
+                    "serial": "container_containerhottext_666ad7e051312229314143",
+                    "body": "\n          <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...<\/p>\n        ",
+                    "elements": {},
+                    "attributes": [],
+                    "debug": {
+                        "relatedItem": "item_666ad7e04dbfa162481935"
+                    }
+                },
+                "debug": {
+                    "relatedItem": "item_666ad7e04dbfa162481935"
+                },
+                "prompt": {
+                    "serial": "container_containerstatic_666ad7e0512d7853841108",
+                    "body": "",
+                    "elements": {},
+                    "attributes": [],
+                    "debug": {
+                        "relatedItem": "item_666ad7e04dbfa162481935"
+                    }
+                }
+            }
+        },
+        "attributes": [],
+        "debug": {
+            "relatedItem": "item_666ad7e04dbfa162481935"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_666ad7e04dbfa162481935"
+    },
+    "namespaces": {
+        "": "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2",
+        "m": "http:\/\/www.w3.org\/1998\/Math\/MathML",
+        "xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance"
+    },
+    "schemaLocations": {
+        "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2": "http:\/\/www.imsglobal.org\/xsd\/qti\/qtiv2p2\/imsqti_v2p2.xsd"
+    },
+    "stylesheets": {},
+    "outcomes": {
+        "outcomedeclaration_666ad7e04ed97862805920": {
+            "identifier": "OUTCOME_1",
+            "serial": "outcomedeclaration_666ad7e04ed97862805920",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "OUTCOME_1",
+                "cardinality": "single",
+                "baseType": "float",
+                "longInterpretation": "",
+                "externalScored": "human",
+                "normalMaximum": 1,
+                "normalMinimum": 0
+            },
+            "debug": {
+                "relatedItem": "item_666ad7e04dbfa162481935"
+            },
+            "defaultValue": null
+        },
+        "outcomedeclaration_666ad7e04f8bc562427531": {
+            "identifier": "SCORE",
+            "serial": "outcomedeclaration_666ad7e04f8bc562427531",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "SCORE",
+                "cardinality": "single",
+                "baseType": "float",
+                "longInterpretation": "",
+                "normalMaximum": 0,
+                "normalMinimum": 0
+            },
+            "debug": {
+                "relatedItem": "item_666ad7e04dbfa162481935"
+            },
+            "defaultValue": null
+        },
+        "outcomedeclaration_666ad7e04f8de522536800": {
+            "identifier": "MAXSCORE",
+            "serial": "outcomedeclaration_666ad7e04f8de522536800",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "MAXSCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_666ad7e04dbfa162481935"
+            },
+            "defaultValue": "1"
+        }
+    },
+    "responses": {
+        "responsedeclaration_666ad7e04eaa4288513651": {
+            "identifier": "RESPONSE",
+            "serial": "responsedeclaration_666ad7e04eaa4288513651",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE",
+                "cardinality": "multiple",
+                "baseType": "identifier"
+            },
+            "debug": {
+                "relatedItem": "item_666ad7e04dbfa162481935"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "no_response_processing",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        },
+        "responsedeclaration_666ad7e04ec84171775656": {
+            "identifier": "RESPONSE_1",
+            "serial": "responsedeclaration_666ad7e04ec84171775656",
+            "qtiClass": "responseDeclaration",
+            "attributes": {
+                "identifier": "RESPONSE_1",
+                "cardinality": "multiple",
+                "baseType": "identifier"
+            },
+            "debug": {
+                "relatedItem": "item_666ad7e04dbfa162481935"
+            },
+            "defaultValue": [],
+            "mapping": [],
+            "areaMapping": [],
+            "howMatch": "no_response_processing",
+            "correctResponses": [],
+            "mappingAttributes": {
+                "defaultValue": 0
+            },
+            "feedbackRules": {}
+        }
+    },
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_templatesdriven_666ad7e051b2d784211813",
+        "qtiClass": "responseProcessing",
+        "attributes": {},
+        "debug": {
+            "relatedItem": "item_666ad7e04dbfa162481935"
+        },
+        "processingType": "templateDriven",
+        "responseRules": []
+    },
+    "apipAccessibility": ""
+}


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3693

## What's Changed

- Fixed rules for Deleting `SCORE` and `MAX_SCORE` and applying Default `SCORE` Value
- The `SCORE` and `MAX_SCORE` will be deleted when response processing is none and all other outcomes marked with `External scored` = `none`
-  The `SCORE` and `MAX_SCORE` will NOT be deleted when response processing is none and at least one outcome marked with `External scored` with `Human` or `External machine`
- The default value `0` will be applied for `SCORE` outcome for the case described just above

## How to test
- Create a test and check the cases described in `What's Changed` section.

The changes applied in scope of https://github.com/oat-sa/extension-tao-itemqti/pull/2524
**Deployed** to http://test-viktar.playground.kitchen.it.taocloud.org:41531/tao/Main/login 