### PR TITLE
feat: single order interaction

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
@@ -134,10 +134,17 @@ const render = function (interaction) {
         choiceSelector = `${$choiceArea.selector} >li:not(.deactivated)`,
         resultSelector = `${$resultArea.selector} >li`,
         $dragContainer = $container.find('.drag-container'),
+        isSingleOrder = interaction.attr('order') === 'single',
         orientation =
             interaction.attr('orientation') && orientationSelectionEnabled
                 ? interaction.attr('orientation')
                 : 'vertical';
+
+    if (isSingleOrder) {
+        const $choices = $choiceArea.children('.qti-choice');
+        $container.addClass('test-preview');
+        $resultArea.append($choices);
+    }
 
     let $activeChoice = null,
         scaleX,

--- a/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
@@ -573,20 +573,16 @@ const setResponse = function (interaction, response) {
     const $container = containerHelper.get(interaction);
     const $choiceArea = $('.choice-area', $container);
     const $resultArea = $('.result-area', $container);
-    const $resultItems = $resultArea.children('li');
     const isSingleOrder = interaction.attr('order') === 'single';
 
     if (response === null || _.isEmpty(response)) {
         resetResponse(interaction);
     } else {
         try {
-            const detachedItems = $resultItems.detach();
             _.forEach(pciResponse.unserialize(response, interaction), function (identifier) {
-                if (isSingleOrder) {
-                    $resultArea.append(detachedItems.filter(`[data-identifier="${identifier}"]`));
-                } else {
-                    $resultArea.append($choiceArea.find(`[data-identifier="${identifier}"]`));
-                }
+                $resultArea.append(
+                    (isSingleOrder ? $resultArea : $choiceArea).find(`[data-identifier="${identifier}"]`)
+                );
             });
         } catch (e) {
             throw new Error(`wrong response format in argument : ${e}`);

--- a/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
@@ -101,19 +101,31 @@ const _setInstructions = function (interaction) {
 };
 
 const resetResponse = function (interaction) {
+    const isSingleOrder = interaction.attr('order') === 'single';
     const $container = containerHelper.get(interaction);
     const initialOrder = _.keys(interaction.getChoices());
-    const $choiceArea = $('.choice-area', $container).append($('.result-area>li', $container));
-    const $choices = $choiceArea.children('.qti-choice');
+    const $resultArea = $('.result-area', $container);
+    const $resultItems = $('.result-area>li', $container);
 
     $container.find('.qti-choice.active').each(function deactivateChoice() {
         interactUtils.tapOn(this);
     });
 
-    $choices.detach().sort(function (choice1, choice2) {
-        return _.indexOf(initialOrder, $(choice1).data('serial')) - _.indexOf(initialOrder, $(choice2).data('serial'));
-    });
-    $choiceArea.prepend($choices);
+    if (isSingleOrder) {
+        // if it's a single order interaction, sort the items in result-area in initial order
+        $resultItems.detach().sort(function (item1, item2) {
+            return _.indexOf(initialOrder, $(item1).data('serial')) - _.indexOf(initialOrder, $(item2).data('serial'));
+        });
+        $resultArea.empty();
+        $resultArea.append($resultItems);
+    } else {
+        const $choiceArea = $('.choice-area', $container).append($('.result-area>li', $container));
+        const $choices = $choiceArea.children('.qti-choice');
+        $choices.detach().sort(function (choice1, choice2) {
+            return _.indexOf(initialOrder, $(choice1).data('serial')) - _.indexOf(initialOrder, $(choice2).data('serial'));
+        });
+        $choiceArea.prepend($choices);
+    }
 };
 
 /**
@@ -561,13 +573,20 @@ const setResponse = function (interaction, response) {
     const $container = containerHelper.get(interaction);
     const $choiceArea = $('.choice-area', $container);
     const $resultArea = $('.result-area', $container);
+    const $resultItems = $resultArea.children('li');
+    const isSingleOrder = interaction.attr('order') === 'single';
 
     if (response === null || _.isEmpty(response)) {
         resetResponse(interaction);
     } else {
         try {
+            const detachedItems = $resultItems.detach();
             _.forEach(pciResponse.unserialize(response, interaction), function (identifier) {
-                $resultArea.append($choiceArea.find(`[data-identifier="${identifier}"]`));
+                if (isSingleOrder) {
+                    $resultArea.append(detachedItems.filter(`[data-identifier="${identifier}"]`));
+                } else {
+                    $resultArea.append($choiceArea.find(`[data-identifier="${identifier}"]`));
+                }
             });
         } catch (e) {
             throw new Error(`wrong response format in argument : ${e}`);

--- a/src/qtiCommonRenderer/tpl/interactions/orderInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/orderInteraction.tpl
@@ -1,4 +1,4 @@
-<div {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-blockInteraction qti-orderInteraction{{#if horizontal}} qti-horizontal{{else}} qti-vertical{{/if}}{{#if attributes.class}} {{attributes.class}}{{/if}}"
+<div {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-blockInteraction qti-orderInteraction{{#if horizontal}} qti-horizontal{{else}} qti-vertical{{/if}}{{#if attributes.class}} {{attributes.class}}{{/if}}{{#equal attributes.order 'single'}} qti-single{{/equal}}"
      data-serial="{{serial}}"
      data-qti-class="orderInteraction"
      data-orientation="{{#if horizontal}}horizontal{{else}}vertical{{/if}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3715

## What's Changed

- Added support of new options by order interaction (`single` and `sort` order)

## How to test
- Create an item containing order interactions with `single` and/or `sort` order options
- Check different states, switching between views with different settings

PR in consumer: https://github.com/oat-sa/extension-tao-itemqti/pull/2532

The changes are deployed to [unit-06 construct](https://construct1-oat-unit06.dev.gcp-eu.taocloud.org/tao/Main/login)