### PR TITLE
fix: remove custom outcomes if no responses in the item

### DIFF
--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -170,6 +170,12 @@ export default {
                 item.removeOutcome('MAXSCORE');
                 item.removeOutcome('SCORE');
             }
+            // remove custom outcomes if all interactions are without responses
+            if (_.isEmpty(item.responses)) {
+                customOutcomes.forEach(outcome => {
+                    item.removeOutcome(outcome.id());
+                });
+            }
         }
     },
 

--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -163,15 +163,22 @@ export default {
             const outcomesWithExternalScored = customOutcomes.filter(outcome => {
                 return externalScoredValues.includes(outcome.attr('externalScored'));
             });
+            const isResponsesEmpty = _.isEmpty(item.responses);
             // remove MAXSCORE and SCORE outcome variables when all interactions are configured with none response processing rule,
             // and the externalScored property of the SCORE variable is set to None
             // and there are no other outcome variables with externalScored property set to human or externalMachine
-            if (!scoreOutcome.attr('externalScored') && isAllResponseProcessingRulesNone && outcomesWithExternalScored.size() === 0) {
+            // or in case all interactions are without responses
+            if (
+                (!scoreOutcome.attr('externalScored') &&
+                    isAllResponseProcessingRulesNone &&
+                    outcomesWithExternalScored.size() === 0) ||
+                isResponsesEmpty
+            ) {
                 item.removeOutcome('MAXSCORE');
                 item.removeOutcome('SCORE');
             }
             // remove custom outcomes if all interactions are without responses
-            if (_.isEmpty(item.responses)) {
+            if (isResponsesEmpty) {
                 customOutcomes.forEach(outcome => {
                     item.removeOutcome(outcome.id());
                 });

--- a/test/qtiItem/maxScore/data/no-responses.json
+++ b/test/qtiItem/maxScore/data/no-responses.json
@@ -1,0 +1,69 @@
+{
+    "identifier": "i669517204e97420240715143336d37c",
+    "serial": "item_6695325e7f312981018589",
+    "qtiClass": "assessmentItem",
+    "attributes": {
+        "identifier": "i669517204e97420240715143336d37c",
+        "title": "Item 12",
+        "label": "Item 12",
+        "xml:lang": "en-US",
+        "adaptive": false,
+        "timeDependent": false,
+        "toolName": "TAO",
+        "toolVersion": "2024.08 LTS",
+        "class": ""
+    },
+    "body": {
+        "serial": "container_containeritembody_6695325e7f30a634634763",
+        "body": "\n    <div class=\"grid-row\">\n      <div class=\"col-12\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipisicing ...<\/p>\n      <\/div>\n    <\/div>\n  ",
+        "elements": {},
+        "attributes": [],
+        "debug": {
+            "relatedItem": "item_6695325e7f312981018589"
+        }
+    },
+    "debug": {
+        "relatedItem": "item_6695325e7f312981018589"
+    },
+    "namespaces": {
+        "": "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2",
+        "m": "http:\/\/www.w3.org\/1998\/Math\/MathML",
+        "xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance"
+    },
+    "schemaLocations": {
+        "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p2": "http:\/\/www.imsglobal.org\/xsd\/qti\/qtiv2p2\/imsqti_v2p2.xsd"
+    },
+    "stylesheets": {},
+    "outcomes": {
+        "outcomedeclaration_654ce58fdf6c6514417636": {
+            "identifier": "OUTCOME_1456",
+            "serial": "outcomedeclaration_654ce58fdf6c6514417636",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "OUTCOME_145",
+                "cardinality": "single",
+                "baseType": "float",
+                "longInterpretation": "",
+                "normalMaximum": 10,
+                "normalMinimum": 0
+            },
+            "debug": {
+                "relatedItem": "item_6695325e7f312981018589"
+            },
+            "defaultValue": null
+        }
+    },
+    "responses": {},
+    "feedbacks": {},
+    "responseProcessing": {
+        "serial": "response_templatesdriven_6695325e7f4f3719481730",
+        "qtiClass": "responseProcessing",
+        "attributes": {},
+        "debug": {
+            "relatedItem": "item_6695325e7f312981018589"
+        },
+        "processingType": "templateDriven",
+        "responseRules": []
+    },
+    "apipAccessibility": ""
+}

--- a/test/qtiItem/maxScore/data/no-responses.json
+++ b/test/qtiItem/maxScore/data/no-responses.json
@@ -51,6 +51,34 @@
                 "relatedItem": "item_6695325e7f312981018589"
             },
             "defaultValue": null
+        },
+        "outcomedeclaration_58fdf5897e8ad024055546": {
+            "identifier": "SCORE",
+            "serial": "outcomedeclaration_58fdf5897e8ad024055546",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "SCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_6695325e7f312981018589"
+            },
+            "defaultValue": null
+        },
+        "outcomedeclaration_666ad8e04f8de522536800": {
+            "identifier": "MAXSCORE",
+            "serial": "outcomedeclaration_666ad8e04f8de522536800",
+            "qtiClass": "outcomeDeclaration",
+            "attributes": {
+                "identifier": "MAXSCORE",
+                "cardinality": "single",
+                "baseType": "float"
+            },
+            "debug": {
+                "relatedItem": "item_6695325e7f312981018589"
+            },
+            "defaultValue": "1"
         }
     },
     "responses": {},

--- a/test/qtiItem/maxScore/test.js
+++ b/test/qtiItem/maxScore/test.js
@@ -427,14 +427,14 @@ define([
         { title: 'external scored', data: dataResponseExternalScored, expectedMaximum: 6, maxScore: 6 },
         { title: 'removed MAXSCORE and SCORE', data: dataResponseExternalScoredNone, expectedMaximum: void 0, maxScore: void 0 },
         { title: 'MAXSCORE and SCORE are NOT removed when outcome has external scored', data: dataResponseExternalScoredOutcome, expectedMaximum: 0, maxScore: 1 },
-        { title: 'Outcome variables are removed when there are no responses in the item', data: dataResponseNoResponses, expectedMaximum: void 0, maxScore: void 0, customOutcomes: 0 },
+        { title: 'Outcome variables are removed when there are no responses in the item', data: dataResponseNoResponses, expectedMaximum: void 0, maxScore: void 0, outcomes: 0 },
     ];
 
     QUnit.cases.init(cases).test('setNormalMaximum', function(settings, assert) {
         const expectCount = [
             settings.maxScore,
             settings.expectedMaximum,
-            settings.customOutcomes
+            settings.outcomes
         ].filter(value => !_.isUndefined(value)).length + DEFAULT_EXPECT_COUNT;
         var ready = assert.async();
 
@@ -486,8 +486,8 @@ define([
             } else {
                 assert.ok(_.isUndefined(item.getOutcomeDeclaration('MAXSCORE')), 'MAXSCORE undefined');
             }
-            if (!_.isUndefined(settings.customOutcomes)) {
-                assert.equal(getCustomOutcomes(item).size(), settings.customOutcomes, 'custom outcomes count');
+            if (!_.isUndefined(settings.outcomes)) {
+                assert.equal(_(item.getOutcomes()).size(), settings.outcomes, 'outcomes count');
             }
             assert.expect(expectCount);
         });


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-3735

Fixed the issue when after deleting of an interaction which was contained responses and custom outcome declarations, they will be not deleted properly and will generate inconsistency inside XML

## What's Changed

- Custom outcome declarations are deleted if there are no responses in the item

## How to test
- Create an item with choice interaction, for example, and create a Human response declaration and save it
- Put in the item some shared stimulus with a file and delete the previously added choice interaction and press save
- All outcome declarations should be deleted if no more interactions with responses

Appropriate PR in consumer: https://github.com/oat-sa/extension-tao-itemqti/pull/2549
**Deployed** to https://construct1-oat-unit07.dev.gcp-eu.taocloud.org/tao/Main/login