### PR TITLE
[AUT-3940] Fix: Single order interaction, moving from order to data-order.

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
@@ -101,7 +101,7 @@ const _setInstructions = function (interaction) {
 };
 
 const resetResponse = function (interaction) {
-    const isSingleOrder = interaction.attr('order') === 'single';
+    const isSingleOrder = interaction.attr('data-order') === 'single';
     const $container = containerHelper.get(interaction);
     const initialOrder = _.keys(interaction.getChoices());
     const $resultArea = $('.result-area', $container);
@@ -146,7 +146,7 @@ const render = function (interaction) {
         choiceSelector = `${$choiceArea.selector} >li:not(.deactivated)`,
         resultSelector = `${$resultArea.selector} >li`,
         $dragContainer = $container.find('.drag-container'),
-        isSingleOrder = interaction.attr('order') === 'single',
+        isSingleOrder = interaction.attr('data-order') === 'single',
         orientation =
             interaction.attr('orientation') && orientationSelectionEnabled
                 ? interaction.attr('orientation')
@@ -573,7 +573,7 @@ const setResponse = function (interaction, response) {
     const $container = containerHelper.get(interaction);
     const $choiceArea = $('.choice-area', $container);
     const $resultArea = $('.result-area', $container);
-    const isSingleOrder = interaction.attr('order') === 'single';
+    const isSingleOrder = interaction.attr('data-order') === 'single';
 
     if (response === null || _.isEmpty(response)) {
         resetResponse(interaction);

--- a/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/OrderInteraction.js
@@ -101,7 +101,8 @@ const _setInstructions = function (interaction) {
 };
 
 const resetResponse = function (interaction) {
-    const isSingleOrder = interaction.attr('data-order') === 'single';
+    const orderState = interaction.attr('data-order') || interaction.attr('order');
+    const isSingleOrder = orderState === 'single';
     const $container = containerHelper.get(interaction);
     const initialOrder = _.keys(interaction.getChoices());
     const $resultArea = $('.result-area', $container);
@@ -146,7 +147,8 @@ const render = function (interaction) {
         choiceSelector = `${$choiceArea.selector} >li:not(.deactivated)`,
         resultSelector = `${$resultArea.selector} >li`,
         $dragContainer = $container.find('.drag-container'),
-        isSingleOrder = interaction.attr('data-order') === 'single',
+        orderState = interaction.attr('data-order') || interaction.attr('order'),
+        isSingleOrder = orderState === 'single',
         orientation =
             interaction.attr('orientation') && orientationSelectionEnabled
                 ? interaction.attr('orientation')
@@ -573,7 +575,9 @@ const setResponse = function (interaction, response) {
     const $container = containerHelper.get(interaction);
     const $choiceArea = $('.choice-area', $container);
     const $resultArea = $('.result-area', $container);
-    const isSingleOrder = interaction.attr('data-order') === 'single';
+    // legacy order attr support
+    const orderState = interaction.attr('data-order') || interaction.attr('order');
+    const isSingleOrder = orderState === 'single';
 
     if (response === null || _.isEmpty(response)) {
         resetResponse(interaction);

--- a/src/qtiCommonRenderer/tpl/interactions/orderInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/orderInteraction.tpl
@@ -1,4 +1,4 @@
-<div {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-blockInteraction qti-orderInteraction{{#if horizontal}} qti-horizontal{{else}} qti-vertical{{/if}}{{#if attributes.class}} {{attributes.class}}{{/if}}{{#equal attributes.data-order 'single'}} qti-single{{/equal}}"
+<div {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-blockInteraction qti-orderInteraction{{#if horizontal}} qti-horizontal{{else}} qti-vertical{{/if}}{{#if attributes.class}} {{attributes.class}}{{/if}}{{#equal attributes.data-order 'single'}} qti-single{{/equal}}{{#equal attributes.order 'single'}} qti-single{{/equal}}"
      data-serial="{{serial}}"
      data-qti-class="orderInteraction"
      data-orientation="{{#if horizontal}}horizontal{{else}}vertical{{/if}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>

--- a/src/qtiCommonRenderer/tpl/interactions/orderInteraction.tpl
+++ b/src/qtiCommonRenderer/tpl/interactions/orderInteraction.tpl
@@ -1,4 +1,4 @@
-<div {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-blockInteraction qti-orderInteraction{{#if horizontal}} qti-horizontal{{else}} qti-vertical{{/if}}{{#if attributes.class}} {{attributes.class}}{{/if}}{{#equal attributes.order 'single'}} qti-single{{/equal}}"
+<div {{#if attributes.id}}id="{{attributes.id}}"{{/if}} class="qti-interaction qti-blockInteraction qti-orderInteraction{{#if horizontal}} qti-horizontal{{else}} qti-vertical{{/if}}{{#if attributes.class}} {{attributes.class}}{{/if}}{{#equal attributes.data-order 'single'}} qti-single{{/equal}}"
      data-serial="{{serial}}"
      data-qti-class="orderInteraction"
      data-orientation="{{#if horizontal}}horizontal{{else}}vertical{{/if}}"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>


### PR DESCRIPTION
[Ticket](https://oat-sa.atlassian.net/browse/AUT-3940)

### Demo:
Before:
![image](https://i.imgur.com/GQHyn9C.png)
Now:
![image](https://i.imgur.com/vzy92qa.png)

How to test:
Create item with single order interaction, check data-order attr by save or import.

Related PRs: [#2617](https://github.com/oat-sa/extension-tao-itemqti/pull/2617), [#1329](https://github.com/oat-sa/tao-deliver-fe/pull/1329)