### PR TITLE
fix: cut maxscore to a zero response upper bound if is's set

### DIFF
--- a/src/qtiItem/helper/maxScore.js
+++ b/src/qtiItem/helper/maxScore.js
@@ -304,10 +304,7 @@ export default {
                 return gamp.add(acc, score);
             }, 0);
 
-            //compare the calculated maximum with the mapping upperbound
-            if (responseDeclaration.mappingAttributes.upperBound) {
-                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
-            }
+            max = this.getMaxCutByUpperBound(max, responseDeclaration);
         } else if (template === 'MAP_RESPONSE_POINT') {
             //map point response processing does not work on choice based interaction
             max = 0;
@@ -535,10 +532,7 @@ export default {
                 return gamp.add(acc, score);
             }, 0);
 
-            //compare the calculated maximum with the mapping upperbound
-            if (responseDeclaration.mappingAttributes.upperBound) {
-                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
-            }
+            max = this.getMaxCutByUpperBound(max, responseDeclaration);
         } else if (template === 'MAP_RESPONSE_POINT') {
             max = 0;
         } else if (template === 'NONE') {
@@ -729,10 +723,7 @@ export default {
 
             //console.log(usedChoices, allPossibleMapEntries, sortedMaps);
 
-            //compare the calculated maximum with the mapping upperbound
-            if (responseDeclaration.mappingAttributes.upperBound) {
-                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
-            }
+            max = this.getMaxCutByUpperBound(max, responseDeclaration);
         } else if (template === 'MAP_RESPONSE_POINT') {
             max = false;
         } else if (template === 'NONE') {
@@ -782,10 +773,7 @@ export default {
                 }, 0);
             max = parseFloat(max);
 
-            //compare the calculated maximum with the mapping upperbound
-            if (responseDeclaration.mappingAttributes.upperBound) {
-                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
-            }
+            max = this.getMaxCutByUpperBound(max, responseDeclaration);
         } else if (template === 'NONE') {
             // set max to zero
             max = 0;
@@ -828,10 +816,7 @@ export default {
                 .max();
             max = parseFloat(max);
 
-            //compare the calculated maximum with the mapping upperbound
-            if (responseDeclaration.mappingAttributes.upperBound) {
-                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
-            }
+            max = this.getMaxCutByUpperBound(max, responseDeclaration);
         } else if (template === 'MAP_RESPONSE_POINT') {
             max = 0;
         } else if (template === 'NONE') {
@@ -895,10 +880,7 @@ export default {
                 .max();
             max = parseFloat(max);
 
-            //compare the calculated maximum with the mapping upperbound
-            if (responseDeclaration.mappingAttributes.upperBound) {
-                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
-            }
+            max = this.getMaxCutByUpperBound(max, responseDeclaration);
         } else if (template === 'MAP_RESPONSE_POINT') {
             max = 0;
         } else if (template === 'NONE') {
@@ -934,10 +916,7 @@ export default {
             });
             max = _.max(values);
 
-            //compare the calculated maximum with the mapping upperbound
-            if (responseDeclaration.mappingAttributes.upperBound) {
-                max = Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
-            }
+            max = this.getMaxCutByUpperBound(max, responseDeclaration);
         } else if (template === 'NONE') {
             // set max to zero
             max = 0;
@@ -945,5 +924,14 @@ export default {
             max = 0;
         }
         return max;
+    },
+
+    getMaxCutByUpperBound(max, responseDeclaration) {
+        if (!_.has(responseDeclaration, 'mappingAttributes.upperBound')) {
+            return max;
+        }
+
+        //compare the calculated maximum with the mapping upperbound
+        return Math.min(max, parseFloat(responseDeclaration.mappingAttributes.upperBound || 0));
     }
 };

--- a/test/qtiItem/maxScore/test.js
+++ b/test/qtiItem/maxScore/test.js
@@ -162,7 +162,6 @@ define([
             maxScore: 3,
             changeData: function(data) {
                 data.responses.responsedeclaration_58eb4dfbd4a74001643639.mappingAttributes.defaultValue = 3;
-                data.responses.responsedeclaration_58eb4dfbd4a74001643639.mappingAttributes.upperBound = 0;
                 return data;
             }
         },
@@ -173,7 +172,6 @@ define([
             maxScore: 5,
             changeData: function(data) {
                 data.responses.responsedeclaration_58eb4dfbd4a74001643639.mappingAttributes.defaultValue = 3;
-                data.responses.responsedeclaration_58eb4dfbd4a74001643639.mappingAttributes.upperBound = 0;
                 delete data.responses.responsedeclaration_58eb4dfbd4a74001643639.mapping.choice_3;
                 return data;
             }


### PR DESCRIPTION
We allow to set 0 upperBound in response map or disable upperBound at all, the issue was that we did not separate max score outcome value calculation logic for that two cases and treated 0 as disabled upperBound
This is follow up change
[AUT-4062](https://oat-sa.atlassian.net/browse/AUT-4062)

[AUT-4062]: https://oat-sa.atlassian.net/browse/AUT-4062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ