### PR TITLE
Feature/tr 6448/vertical inlinechoice

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -81,6 +81,7 @@ const render = function (interaction, options) {
     const dirClass = getItemDir();
     const writingMode = getItemWritingMode();
     const isVertical = writingMode === 'vertical-rl';
+    const serial = $container.data('serial');
 
     $container.select2({
         data: $container
@@ -111,10 +112,14 @@ const render = function (interaction, options) {
         choiceTooltip = tooltip.warning($el, __('A choice must be selected'), {
             placement: isVertical ? 'right' : 'top'
         });
-
         if ($container.val() === '') {
             choiceTooltip.show();
         }
+        //refresh tooltip position when all styles loaded.
+        $(document).on(`themeapplied.inlineChoiceInteraction-${serial}`, () => {
+            choiceTooltip.hide();
+            choiceTooltip.show();
+        });
     }
 
     $container
@@ -200,9 +205,11 @@ const getResponse = function (interaction) {
  */
 const destroy = function (interaction) {
     const $container = containerHelper.get(interaction);
+    const serial = $container.data('serial');
 
     //remove event
     $(document).off('.commonRenderer');
+    $(document).off(`.inlineChoiceInteraction-${serial}`);
 
     $container.select2('destroy');
 

--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -72,7 +72,14 @@ const render = function (interaction, options) {
         return itemDir;
     };
 
+    const getItemWritingMode = () => {
+        const itemBody = $('.qti-itemBody');
+        const itemWritingMode = itemBody.hasClass('writing-mode-vertical-rl') ? 'vertical-rl' : '';
+        return itemWritingMode;
+    }
+
     const dirClass = getItemDir();
+    const writingMode = getItemWritingMode();
     $container.select2({
         data: $container
             .find(optionSelector)
@@ -91,7 +98,8 @@ const render = function (interaction, options) {
         placeholder: opts.placeholderText,
         minimumResultsForSearch: -1,
         containerCssClass: `${dirClass}`,
-        dropdownCssClass: `qti-inlineChoiceInteraction-dropdown ${dirClass}`
+        dropdownCssClass: `qti-inlineChoiceInteraction-dropdown ${dirClass}`,
+        writingMode
     });
 
     const $el = $container.select2('container');

--- a/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/InlineChoiceInteraction.js
@@ -76,10 +76,12 @@ const render = function (interaction, options) {
         const itemBody = $('.qti-itemBody');
         const itemWritingMode = itemBody.hasClass('writing-mode-vertical-rl') ? 'vertical-rl' : '';
         return itemWritingMode;
-    }
+    };
 
     const dirClass = getItemDir();
     const writingMode = getItemWritingMode();
+    const isVertical = writingMode === 'vertical-rl';
+
     $container.select2({
         data: $container
             .find(optionSelector)
@@ -106,7 +108,9 @@ const render = function (interaction, options) {
 
     if (required) {
         //set up the tooltip plugin for the input
-        choiceTooltip = tooltip.warning($el, __('A choice must be selected'));
+        choiceTooltip = tooltip.warning($el, __('A choice must be selected'), {
+            placement: isVertical ? 'right' : 'top'
+        });
 
         if ($container.val() === '') {
             choiceTooltip.show();
@@ -152,8 +156,6 @@ const _setVal = function (interaction, choiceIdentifier) {
 const resetResponse = function (interaction) {
     _setVal(interaction, _emptyValue);
 };
-
-
 
 /**
  * Set the response to the rendered interaction.


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-6448

`writing-mode: vertical-rl` for InlineChoiceInteraction.

### Related PRs:
- base item layout: see list here: https://github.com/oat-sa/extension-tao-itemqti/pull/2669
- inline choice interaction		
  - https://github.com/oat-sa/tao-core-libs-fe/pull/117
  - https://github.com/oat-sa/tao-item-runner-qti-fe/pull/419
  - https://github.com/oat-sa/extension-tao-itemqti/pull/2671
  - https://github.com/oat-sa/tao-core-ui-fe/pull/630
  - https://github.com/oat-sa/tao-core/pull/4195