### PR TITLE
fix: Enforce validation during keyboard selection

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ChoiceInteraction.js
@@ -126,6 +126,9 @@ const _pseudoLabel = function _pseudoLabel(interaction, $container) {
 
         // if the click has been triggered by a keyboard check, prevent this listener to cancel this check
         if (e.originalEvent && $(e.originalEvent.target).is('input')) {
+            instructionMgr.validateInstructions(interaction, { choice: $choiceBox });
+            containerHelper.triggerResponseChangeEvent(interaction);
+            $(input).focus();
             return;
         }
 


### PR DESCRIPTION
Related to: [INF-209](https://oat-sa.atlassian.net/browse/INF-209)

Previously, the maxChoices validation was only enforced during mouse selection but was being bypassed when choices were selected using keyboard navigation (space key). This fix adds the same validation checks to keyboard selection when an input event is triggered via keyboard, ensuring consistent behavior across both mouse and keyboard interactions.

https://github.com/user-attachments/assets/2c96b8cb-d6f7-4a7a-b7c9-74c4cbe2fb62



[INF-209]: https://oat-sa.atlassian.net/browse/INF-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ