### PR TITLE
Fix: MediaInteraction cast currentWidth to string before testing for %

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/MediaInteraction.js
@@ -82,7 +82,7 @@ function render(interaction) {
             // only resize when width in px
             // new version has width in %
             const  currentWidth = media.attr('width');
-            if (interaction.mediaElement && currentWidth && !currentWidth.includes('%')) {
+            if (interaction.mediaElement && currentWidth && !`${currentWidth}`.includes('%')) {
                 const height = $container.find('.media-container').height();
                 const width = $container.find('.media-container').width();
 


### PR DESCRIPTION
Just encountered a bug when testing media in CG. It happens in a resize handler, testing if a Number value `.includes('%')`.

<img width="992" alt="Screenshot 2025-02-25 at 15 15 29" src="https://github.com/user-attachments/assets/b4824e61-8181-4e50-8263-0c6cbe3784e6" />
