### PR TITLE
[INF-285] Fix: change for text area value restrictions when input done by not regular tools

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -741,6 +741,14 @@ function inputLimiter(interaction) {
                         }
                         _.defer(() => limiter.updateCounter());
                     };
+                    editor.on('instanceReady', function () {
+                        const self = this;
+                        const editableElement = editor.editable().$;
+                        editableElement.addEventListener('compositionend', function () {
+                            CKEditorKeyLimit.call(self);
+                            _.defer(() => limiter.updateCounter());
+                        });
+                    });
                     editor.on('key', CKEditorKeyLimit);
                     editor.on('blur', CKEditorKeyLimit);
                 }

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -739,12 +739,10 @@ function inputLimiter(interaction) {
                         } else {
                             previousSnapshot = editor.getSnapshot();
                         }
+                        _.defer(() => limiter.updateCounter());
                     };
                     editor.on('key', CKEditorKeyLimit);
-                    editor.on('blur', function () {
-                        CKEditorKeyLimit.call(this);
-                        _.defer(() => limiter.updateCounter());
-                    });
+                    editor.on('blur', CKEditorKeyLimit);
                 }
                 editor.on('key', keyLimitHandler);
                 editor.on('change', evt => {

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -723,13 +723,12 @@ function inputLimiter(interaction) {
                 return e;
             };
 
-            if (_getFormat(interaction) === 'xhtml') {
+            if (isCke) {
                 const editor = _getCKEditor(interaction);
 
                 if (maxLength) {
                     let previousSnapshot = editor.getSnapshot();
-
-                    editor.on('key', function () {
+                    const CKEditorKeyLimit = () => {
                         const range = this.createRange();
                         if (limiter.getCharsCount() > limiter.maxLength) {
                             const editable = this.editable();
@@ -737,10 +736,12 @@ function inputLimiter(interaction) {
                             editable.setData(previousSnapshot, true);
                             range.moveToElementEditablePosition(editable, true);
                             editor.getSelection().selectRanges([range]);
-                            return;
+                        } else {
+                            previousSnapshot = editor.getSnapshot();
                         }
-                        previousSnapshot = editor.getSnapshot();
-                    });
+                    };
+                    editor.on('key', CKEditorKeyLimit);
+                    editor.on('blur', CKEditorKeyLimit);
                 }
                 editor.on('key', keyLimitHandler);
                 editor.on('change', evt => {

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -728,7 +728,7 @@ function inputLimiter(interaction) {
 
                 if (maxLength) {
                     let previousSnapshot = editor.getSnapshot();
-                    const CKEditorKeyLimit = () => {
+                    const CKEditorKeyLimit = function () {
                         const range = this.createRange();
                         if (limiter.getCharsCount() > limiter.maxLength) {
                             const editable = this.editable();
@@ -741,7 +741,10 @@ function inputLimiter(interaction) {
                         }
                     };
                     editor.on('key', CKEditorKeyLimit);
-                    editor.on('blur', CKEditorKeyLimit);
+                    editor.on('blur', function () {
+                        CKEditorKeyLimit.call(this);
+                        _.defer(() => limiter.updateCounter());
+                    });
                 }
                 editor.on('key', keyLimitHandler);
                 editor.on('change', evt => {

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -703,13 +703,14 @@ function inputLimiter(interaction) {
             };
 
             const handleCompositionEnd = e => {
+                e.preventDefault();
                 isComposing = false;
                 hasCompositionJustEnded = true;
                 // if plain text - then limit input right after composition end event
                 if (_getFormat(interaction) !== 'xhtml' && maxLength !== null) {
                     const currentValue = $textarea[0].value;
                     const currentLength= this.getCharsCount();
-                    if (currentLength >= maxLength) {
+                    if (currentLength > maxLength) {
                         $textarea[0].value = currentValue.slice(0, maxLength - currentLength);
                     }
                 }
@@ -732,6 +733,7 @@ function inputLimiter(interaction) {
                         const range = this.createRange();
                         if (limiter.getCharsCount() > limiter.maxLength) {
                             const editable = this.editable();
+                            editable.setData('', true);
                             editable.setData(previousSnapshot, true);
                             range.moveToElementEditablePosition(editable, true);
                             editor.getSelection().selectRanges([range]);
@@ -755,7 +757,7 @@ function inputLimiter(interaction) {
                         _.defer(() => this.updateCounter());
                     })
                     .on('compositionstart.commonRenderer', handleCompositionStart)
-                    .on('compositionend.commonRenderer', handleCompositionEnd)
+                    .on('compositionend.commonRenderer blur', handleCompositionEnd)
                     .on('keyup.commonRenderer', patternHandler)
                     .on('keydown.commonRenderer', keyLimitHandler)
                     .on('paste.commonRenderer drop.commonRenderer', nonKeyLimitHandler);

--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -708,7 +708,10 @@ function inputLimiter(interaction) {
                 // if plain text - then limit input right after composition end event
                 if (_getFormat(interaction) !== 'xhtml' && maxLength !== null) {
                     const currentValue = $textarea[0].value;
-                    $textarea[0].value = currentValue.substring(0, maxLength);
+                    const currentLength= this.getCharsCount();
+                    if (currentLength >= maxLength) {
+                        $textarea[0].value = currentValue.slice(0, maxLength - currentLength);
+                    }
                 }
                 _.defer(() => this.updateCounter());
                 return e;


### PR DESCRIPTION
[INF-285](https://oat-sa.atlassian.net/browse/INF-285)

Fix for non standard input in extended text interaction.

How to reproduce:
- Create item with extended text interaction
- Set constrains to max length
- Run preview
- Try Japanese input 

Before：
![image](https://i.imgur.com/Uig43AK.gif)
After
![image](https://i.imgur.com/wNHJPMS.gif)

[INF-285]: https://oat-sa.atlassian.net/browse/INF-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ