### PR TITLE
[AUT-4134] Fix: for trigger empty raphael element events in Select Point interaction

### DIFF
--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -733,7 +733,7 @@ const GraphicHelper = {
      *
      */
     trigger: function (element, event) {
-        const evt = element.events.filter(el => el.name === event);
+        const evt = element.events?.filter(el => el.name === event) || [];
         if (evt.length && evt[0] && typeof evt[0].f === 'function') {
             evt[0].f.apply(element, Array.prototype.slice.call(arguments, 2));
         }

--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -733,8 +733,8 @@ const GraphicHelper = {
      *
      */
     trigger: function (element, event) {
-        const evt = element.events?.filter(el => el.name === event) || [];
-        if (evt.length && evt[0] && typeof evt[0].f === 'function') {
+        const evt = element.events?.filter(el => el.name === event);
+        if (evt && evt.length && evt[0] && typeof evt[0].f === 'function') {
             evt[0].f.apply(element, Array.prototype.slice.call(arguments, 2));
         }
     },

--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -733,8 +733,8 @@ const GraphicHelper = {
      *
      */
     trigger: function (element, event) {
-        const evt = element.events?.filter(el => el.name === event);
-        if (evt && evt.length && evt[0] && typeof evt[0].f === 'function') {
+        const evt = element.events.filter(el => el.name === event) || [];
+        if (evt.length && evt[0] && typeof evt[0].f === 'function') {
             evt[0].f.apply(element, Array.prototype.slice.call(arguments, 2));
         }
     },

--- a/src/qtiCommonRenderer/helpers/Graphic.js
+++ b/src/qtiCommonRenderer/helpers/Graphic.js
@@ -733,7 +733,7 @@ const GraphicHelper = {
      *
      */
     trigger: function (element, event) {
-        const evt = element.events.filter(el => el.name === event) || [];
+        const evt = element.events.filter(el => el.name === event);
         if (evt.length && evt[0] && typeof evt[0].f === 'function') {
             evt[0].f.apply(element, Array.prototype.slice.call(arguments, 2));
         }

--- a/src/qtiCommonRenderer/renderers/interactions/SelectPointInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/SelectPointInteraction.js
@@ -210,6 +210,12 @@ const resetResponse = function resetResponse(interaction) {
         interaction.paper.forEach(function(element) {
             const point = element.data('point');
             if (typeof point === 'object') {
+
+                if(!element.events) {
+                    // fix for error on empty raphael triggers
+                    element.events = [];
+                }
+
                 graphic.trigger(element, 'click');
             }
         });


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-4134

Select Point fix, broken switch between Q&A modes

**Steps to reproduce:**
- Open an item in Authoring mode
- Drag and drop Select Point interaction on the canvas
- Click 'Response' button
- Drag and drop target on the canvas
- Click 'Question' button
- Click 'Response' button

Broken:
![image](https://i.imgur.com/is2HAXS.gif)

Fixed: 
![image](https://i.imgur.com/upkYFtD.gif)