### PR TITLE
fix/ADF-1908/rtl-styles-from-item-body

### DIFF
--- a/src/runner/provider/qti.js
+++ b/src/runner/provider/qti.js
@@ -83,13 +83,20 @@ var qtiItemRuntimeProvider = {
                 //render item html
                 elt.innerHTML = this._item.render({});
 
+                //check rtl is set in body attributes of an item
+                const bdyRTL = this._item.bdy && this._item.bdy.attr('dir') === 'rtl';
+
                 // apply RTL layout according to item language
                 const $item = $(elt).find('.qti-item');
                 const $itemBody = $item.find('.qti-itemBody');
                 const itemDir = $itemBody.attr('dir');
                 if (!itemDir) {
-                    const itemLang = $item.attr('lang');
-                    $itemBody.attr('dir', locale.getLanguageDirection(itemLang));
+                    if(bdyRTL) {
+                        $itemBody.attr('dir', 'rtl');
+                    }else{
+                        const itemLang = $item.attr('lang');
+                        $itemBody.attr('dir', locale.getLanguageDirection(itemLang));
+                    }
                 }
                 if ($itemBody.hasClass('writing-mode-vertical-rl')) {
                     document.body.classList.add('item-writing-mode-vertical-rl');


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/ADF-1908

### Description

This sets the rtl attribute of an item based on item body provided attribute. Previous behaviour is still in place for a fallback routine

### How to test

Unit03:
https://construct1-oat-unit03.dev.gcp-eu.taocloud.org/tao/Main/login

Locally:
 -  check the configuration set in `tao/config/tao/client_lib_config_registry.conf.php` under 'util/locale' -> 'rtl' , y default there is only 'ar-arb' specified
 - create some item with rtl language like `Kurdish (Iran)`
 - check item previewer, the item should be displayed in rtl
 
 