### PR TITLE
chore: add link to package changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@oat-sa/prettier-config": "^0.1.1",
                 "@oat-sa/rollup-plugin-wildcard-external": "^1.0.0",
                 "@oat-sa/tao-core-libs": "^1.1.0",
-                "@oat-sa/tao-core-sdk": "^3.0.0",
+                "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#fix/AUT-4106/removed-hardcoded-mime-extensions",
                 "@oat-sa/tao-core-shared-libs": "^1.4.1",
                 "@oat-sa/tao-core-ui": "^3.10.0",
                 "@oat-sa/tao-item-runner": "^1.0.0",
@@ -892,26 +892,21 @@
             }
         },
         "node_modules/@oat-sa/tao-core-sdk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-3.0.0.tgz",
-            "integrity": "sha512-YfTY2tFNNjgVcy0SalWkGRRfuTnfIxQaW9rAF7O/8Dff5vWzsJ+80AubFJa4fviJVB7QUzl+Etr24mjDoAZO+g==",
+            "version": "3.2.1",
+            "resolved": "git+ssh://git@github.com/oat-sa/tao-core-sdk-fe.git#55056f1de5628cd3471983801669a1630ab7b7c0",
             "dev": true,
+            "license": "GPL-2.0",
             "dependencies": {
-                "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.2",
-                "webcrypto-shim": "0.1.7"
+                "jquery": "1.9.1",
+                "lodash": "^4.17.21",
+                "moment": "^2.29.4"
             }
         },
         "node_modules/@oat-sa/tao-core-sdk/node_modules/idb-wrapper": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
             "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg==",
-            "dev": true
-        },
-        "node_modules/@oat-sa/tao-core-sdk/node_modules/webcrypto-shim": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
-            "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg==",
             "dev": true
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
@@ -3585,12 +3580,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true
-        },
-        "node_modules/fastestsmallesttextencoderdecoder": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
-            "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ==",
             "dev": true
         },
         "node_modules/fastq": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@oat-sa/prettier-config": "^0.1.1",
                 "@oat-sa/rollup-plugin-wildcard-external": "^1.0.0",
                 "@oat-sa/tao-core-libs": "^1.1.0",
-                "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#fix/AUT-4106/removed-hardcoded-mime-extensions",
+                "@oat-sa/tao-core-sdk": "^3.3.1",
                 "@oat-sa/tao-core-shared-libs": "^1.4.1",
                 "@oat-sa/tao-core-ui": "^3.10.0",
                 "@oat-sa/tao-item-runner": "^1.0.0",
@@ -892,10 +892,10 @@
             }
         },
         "node_modules/@oat-sa/tao-core-sdk": {
-            "version": "3.2.1",
-            "resolved": "git+ssh://git@github.com/oat-sa/tao-core-sdk-fe.git#55056f1de5628cd3471983801669a1630ab7b7c0",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-3.3.1.tgz",
+            "integrity": "sha512-lX5o6g08aC4Rp4Un7GCtdQ4JS+YD43zJFJ3cCG56mLA3sKY4HGF23m184ff0GEaoKdxoYa6K9KQlAwM6ww8fvg==",
             "dev": true,
-            "license": "GPL-2.0",
             "dependencies": {
                 "idb-wrapper": "1.7.2",
                 "jquery": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^1.0.0",
         "@oat-sa/tao-core-libs": "^1.1.0",
-        "@oat-sa/tao-core-sdk": "^3.0.0",
+        "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#fix/AUT-4106/removed-hardcoded-mime-extensions",
         "@oat-sa/tao-core-shared-libs": "^1.4.1",
         "@oat-sa/tao-core-ui": "^3.10.0",
         "@oat-sa/tao-item-runner": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^1.0.0",
         "@oat-sa/tao-core-libs": "^1.1.0",
-        "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#fix/AUT-4106/removed-hardcoded-mime-extensions",
+        "@oat-sa/tao-core-sdk": "^3.3.1",
         "@oat-sa/tao-core-shared-libs": "^1.4.1",
         "@oat-sa/tao-core-ui": "^3.10.0",
         "@oat-sa/tao-item-runner": "^1.0.0",


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/AUT-4106

**Description:**
Some mime types have the extension hardcoded in the label. There is no need now that the extension has been added to the list

**Changes:**

- Link to the FE package with the change https://github.com/oat-sa/tao-core-sdk-fe/pull/194

**How to check:**
- Code available to check in [unit13](https://tenant01-oat-unit13.dev.gcp-eu.taocloud.org/login)
- Check in the companion PR https://github.com/oat-sa/extension-tao-itemqti/pull/2690