### PR TITLE
Fix/INF-333/extendedtext: text was cut to 0 chars if no maxlength

### DIFF
--- a/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
+++ b/src/qtiCommonRenderer/renderers/interactions/ExtendedTextInteraction.js
@@ -703,13 +703,12 @@ function inputLimiter(interaction) {
             };
 
             const handleCompositionEnd = e => {
-                e.preventDefault();
                 isComposing = false;
                 hasCompositionJustEnded = true;
                 // if plain text - then limit input right after composition end event
-                if (_getFormat(interaction) !== 'xhtml' && maxLength !== null) {
+                if (_getFormat(interaction) !== 'xhtml' && maxLength) {
                     const currentValue = $textarea[0].value;
-                    const currentLength= this.getCharsCount();
+                    const currentLength = this.getCharsCount();
                     if (currentLength > maxLength) {
                         $textarea[0].value = currentValue.slice(0, maxLength - currentLength);
                     }
@@ -767,7 +766,7 @@ function inputLimiter(interaction) {
                         _.defer(() => this.updateCounter());
                     })
                     .on('compositionstart.commonRenderer', handleCompositionStart)
-                    .on('compositionend.commonRenderer blur', handleCompositionEnd)
+                    .on('compositionend.commonRenderer', handleCompositionEnd)
                     .on('keyup.commonRenderer', patternHandler)
                     .on('keydown.commonRenderer', keyLimitHandler)
                     .on('paste.commonRenderer drop.commonRenderer', nonKeyLimitHandler);


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/INF-333

[Deployed to unit01](https://oat-sa.atlassian.net/browse/TR-6452?focusedCommentId=305524)

Have plain ExtendedText _without_ `maxlength`.
Enter something (normally or using IME composition).
Blur or finish composition.
Text is lost --> because `maxlength: 0`, which passes `maxlength !== null` check


Was broken in https://github.com/oat-sa/tao-item-runner-qti-fe/pull/253 ? Or at that time `patternMask = ""` was true and authoring/compilation changed later?
Not related to [INF-285](https://oat-sa.atlassian.net/browse/INF-285)

Failing unit test was fixed in another PR: https://github.com/oat-sa/tao-item-runner-qti-fe/pull/442/commits/38b8f4ba974249344dd7b0d6ff0a2cbb0730b507

[INF-285]: https://oat-sa.atlassian.net/browse/INF-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ