### PR TITLE
Fix/tr 6577/vertical writing numbers

### DIFF
--- a/src/qtiCommonRenderer/tpl/instruction.tpl
+++ b/src/qtiCommonRenderer/tpl/instruction.tpl
@@ -1,3 +1,3 @@
 <div id="{{serial}}" class="small feedback-info item-instruction"{{#if attributes.xml:lang}} lang="{{attributes.xml:lang}}"{{/if}}>
-    <span class="icon-info icon"></span><span class="instruction-message">{{message}}</span>
+    <span class="icon-info icon"></span><span class="instruction-message">{{{message}}}</span>
 </div>


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-6577

Use with https://github.com/oat-sa/extension-tao-itemqti/pull/2755
Deployed to [unit01](https://oat-sa.atlassian.net/browse/TR-6452?focusedCommentId=305524) "_Delivery of jun25 jap numbers_"

Vertical-writing, ChoiceInteraction, maxChoices feedback:
for a moment after load, html markup is shown as a plain text. After a couple of seconds, it's replaced with proper markup.

Solution: in [Instruction.update](https://github.com/oat-sa/tao-item-runner-qti-fe/blob/develop/src/qtiCommonRenderer/helpers/instructions/Instruction.js#L62) `message` is already set as html, so we need to do the same when rendering *.tpl in `Instruction.create`.


![jap–min max in choice](https://github.com/user-attachments/assets/87dff3a1-5990-45ff-ba35-48b9d75512c1)

