### PR TITLE
fix: add isNull to response feedback rules

### DIFF
--- a/src/qtiItem/core/response/SimpleFeedbackRule.js
+++ b/src/qtiItem/core/response/SimpleFeedbackRule.js
@@ -48,6 +48,7 @@ var SimpleFeedbackRule = Element.extend({
             switch (condition) {
                 case 'correct':
                 case 'incorrect':
+                case 'isNull':
                     if (Element.isA(comparedOutcome, 'responseDeclaration')) {
                         this.comparedOutcome = comparedOutcome;
                         this.condition = condition;


### PR DESCRIPTION
#https://oat-sa.atlassian.net/browse/TR-5815

## Goal
fix: add isNull to response feedback rules

## How to test / use
Select `is null` in the Response feedback rules

## Changelog
Add `isNull` condition