### PR TITLE
[INF-537] Fix: extend reviewRender with single order render logic

### DIFF
--- a/src/reviewRenderer/renderers/interactions/OrderInteraction.js
+++ b/src/reviewRenderer/renderers/interactions/OrderInteraction.js
@@ -40,6 +40,14 @@ const _freezeSize = function($container) {
 const render = function(interaction) {
     const $container = containerHelper.get(interaction);
 
+    const orderState = interaction.attr('data-order') || interaction.attr('order');
+    if (orderState === 'single') {
+        const $choiceArea = $container.find('.choice-area');
+        const $resultArea = $container.find('.result-area');
+        $container.addClass('test-preview');
+        $resultArea.append($choiceArea.children('.qti-choice'));
+    }
+
     //bind event listener in case the attributes change dynamically on runtime
     $(document).on('attributeChange.qti-widget.commonRenderer', (e) => e.preventDefault());
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-537

Additional extension for preview render which allow to render choices in correct order

<img width="1840" height="972" alt="chrome_PcCtFIKQTU" src="https://github.com/user-attachments/assets/89e0746c-a640-4bb3-be07-42d0ea18c36a" />
